### PR TITLE
fix(compose): run full stack locally; remove host links; add MinIO

### DIFF
--- a/PuppyFlow/app/api/auth/verify/route.ts
+++ b/PuppyFlow/app/api/auth/verify/route.ts
@@ -40,7 +40,10 @@ export async function GET(request: Request) {
     } catch {
       // Edge 兜底：从请求头里解析 cookie
       const rawCookie = hdrs.get('cookie') || '';
-      const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+      const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(
+        /[-[\]{}()*+?.,\\^$|#\s]/g,
+        '\\$&'
+      );
       const match = rawCookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
       if (match) {
         authHeader = `Bearer ${decodeURIComponent(match[1])}`;

--- a/PuppyFlow/app/api/engine/[[...path]]/route.ts
+++ b/PuppyFlow/app/api/engine/[[...path]]/route.ts
@@ -10,7 +10,10 @@ function buildTargetUrl(request: Request, path: string[] | undefined): string {
   return `${base}${suffix}${query}`;
 }
 
-function filterRequestHeaders(request: Request, headers: Headers): Record<string, string> {
+function filterRequestHeaders(
+  request: Request,
+  headers: Headers
+): Record<string, string> {
   return filterRequestHeadersAndInjectAuth(request, headers, {
     includeServiceKey: false,
     localFallback: true,

--- a/PuppyFlow/app/api/server/[[...path]]/route.ts
+++ b/PuppyFlow/app/api/server/[[...path]]/route.ts
@@ -23,7 +23,10 @@ function buildTargetUrl(request: Request, path: string[] | undefined): string {
   return `${base}${suffix}${query}`;
 }
 
-function filterRequestHeaders(request: Request, headers: Headers): Record<string, string> {
+function filterRequestHeaders(
+  request: Request,
+  headers: Headers
+): Record<string, string> {
   return filterRequestHeadersAndInjectAuth(request, headers, {
     includeServiceKey: true,
     localFallback: true,

--- a/PuppyFlow/app/api/storage/[[...path]]/route.ts
+++ b/PuppyFlow/app/api/storage/[[...path]]/route.ts
@@ -10,7 +10,10 @@ function buildTargetUrl(request: Request, path: string[] | undefined): string {
   return `${base}${suffix}${query}`;
 }
 
-function filterRequestHeaders(request: Request, headers: Headers): Record<string, string> {
+function filterRequestHeaders(
+  request: Request,
+  headers: Headers
+): Record<string, string> {
   return filterRequestHeadersAndInjectAuth(request, headers, {
     includeServiceKey: true,
     localFallback: true,

--- a/PuppyFlow/app/api/workspace/[workspaceId]/rename/route.ts
+++ b/PuppyFlow/app/api/workspace/[workspaceId]/rename/route.ts
@@ -24,7 +24,10 @@ export async function PUT(
         if (token) authHeader = `Bearer ${token}`;
       } catch {
         const rawCookie = request.headers.get('cookie') || '';
-        const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+        const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(
+          /[-[\]{}()*+?.,\\^$|#\s]/g,
+          '\\$&'
+        );
         const match = rawCookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
         if (match) authHeader = `Bearer ${decodeURIComponent(match[1])}`;
       }

--- a/PuppyFlow/app/api/workspace/[workspaceId]/route.ts
+++ b/PuppyFlow/app/api/workspace/[workspaceId]/route.ts
@@ -24,7 +24,10 @@ export async function DELETE(
         if (token) authHeader = `Bearer ${token}`;
       } catch {
         const rawCookie = request.headers.get('cookie') || '';
-        const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+        const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(
+          /[-[\]{}()*+?.,\\^$|#\s]/g,
+          '\\$&'
+        );
         const match = rawCookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
         if (match) authHeader = `Bearer ${decodeURIComponent(match[1])}`;
       }

--- a/PuppyFlow/app/api/workspace/create/route.ts
+++ b/PuppyFlow/app/api/workspace/create/route.ts
@@ -22,7 +22,10 @@ export async function POST(request: Request) {
         if (token) authHeader = `Bearer ${token}`;
       } catch {
         const rawCookie = request.headers.get('cookie') || '';
-        const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+        const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(
+          /[-[\]{}()*+?.,\\^$|#\s]/g,
+          '\\$&'
+        );
         const match = rawCookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
         if (match) authHeader = `Bearer ${decodeURIComponent(match[1])}`;
       }

--- a/PuppyFlow/app/api/workspace/list/route.ts
+++ b/PuppyFlow/app/api/workspace/list/route.ts
@@ -17,7 +17,10 @@ export async function GET(request: Request) {
         if (token) authHeader = `Bearer ${token}`;
       } catch {
         const rawCookie = request.headers.get('cookie') || '';
-        const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+        const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(
+          /[-[\]{}()*+?.,\\^$|#\s]/g,
+          '\\$&'
+        );
         const match = rawCookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
         if (match) authHeader = `Bearer ${decodeURIComponent(match[1])}`;
       }

--- a/PuppyFlow/lib/auth/serverUser.ts
+++ b/PuppyFlow/lib/auth/serverUser.ts
@@ -24,7 +24,10 @@ export async function getCurrentUserId(request: Request): Promise<string> {
       if (token) authHeader = `Bearer ${token}`;
     } catch {
       const rawCookie = request.headers.get('cookie') || '';
-      const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+      const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(
+        /[-[\]{}()*+?.,\\^$|#\s]/g,
+        '\\$&'
+      );
       const match = rawCookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
       if (match) authHeader = `Bearer ${decodeURIComponent(match[1])}`;
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,18 @@
 version: '3.9'
 
 services:
+  db:
+    image: postgres:15-alpine
+    container_name: puppy_db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=puppy
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
   storage:
     build:
       context: ./PuppyStorage
@@ -27,7 +39,7 @@ services:
     container_name: puppy_engine
     environment:
       - DEPLOYMENT_TYPE=local
-      - USER_SYSTEM_URL=http://host.docker.internal:8000
+      - USER_SYSTEM_URL=http://usersystem:8000
       - STORAGE_SERVER_URL=http://storage:8002
       - SERVICE_KEY
       - OPENROUTER_API_KEY
@@ -53,6 +65,7 @@ services:
       - "8001:8001"
     depends_on:
       - storage
+      - usersystem
 
   flow:
     image: node:18-alpine
@@ -62,10 +75,10 @@ services:
       - ./PuppyFlow:/app
     environment:
       - NODE_ENV=development
-      - USER_SYSTEM_BACKEND=http://host.docker.internal:8000
+      - USER_SYSTEM_BACKEND=http://usersystem:8000
       - PUPPYENGINE_URL=http://engine:8001
       - PUPPYSTORAGE_URL=http://storage:8002
-      - API_SERVER_URL=http://host.docker.internal:8004
+      - API_SERVER_URL=http://api:8004
       - SERVICE_KEY
       - NEXT_PUBLIC_FRONTEND_VERSION=0.1.0
     command: sh -c "npm install && npm run dev"
@@ -74,3 +87,31 @@ services:
     depends_on:
       - engine
       - storage
+
+  usersystem:
+    build:
+      context: ../../PuppyUserSystem
+      dockerfile: Dockerfile
+    container_name: puppy_user_system
+    environment:
+      - PORT=8000
+      - SUPABASE_DATABASE_URL=postgresql://postgres:postgres@db:5432/puppy
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+  api:
+    build:
+      context: ../../PuppyAgent-API
+      dockerfile: Dockerfile
+    container_name: puppy_api
+    environment:
+      - SUPABASE_DATABASE_URL=postgresql://postgres:postgres@db:5432/puppy
+    ports:
+      - "8004:8004"
+    depends_on:
+      - db
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,32 @@
 version: '3.9'
 
 services:
+  minio:
+    image: minio/minio:latest
+    container_name: puppy_minio
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=minio
+      - MINIO_ROOT_PASSWORD=minio12345
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+
+  createbuckets:
+    image: minio/mc:latest
+    container_name: puppy_minio_init
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minio minio12345;
+      mc mb -p local/puppy || true;
+      mc anonymous set download local/puppy || true;
+      exit 0;
+      "
+
   db:
     image: postgres:15-alpine
     container_name: puppy_db
@@ -19,18 +45,21 @@ services:
       dockerfile: Dockerfile
     container_name: puppy_storage
     environment:
-      - DEPLOYMENT_TYPE=local
+      - DEPLOYMENT_TYPE=remote
       - AXIOM_TOKEN
       - AXIOM_ORG_ID
       - AXIOM_DATASET
       - OPENAI_API_KEY
       - SUPABASE_URL
-      - CLOUDFLARE_R2_ENDPOINT
-      - CLOUDFLARE_R2_ACCESS_KEY_ID
-      - CLOUDFLARE_R2_SECRET_ACCESS_KEY
-      - CLOUDFLARE_R2_BUCKET
+      - CLOUDFLARE_R2_ENDPOINT=http://minio:9000
+      - CLOUDFLARE_R2_ACCESS_KEY_ID=minio
+      - CLOUDFLARE_R2_SECRET_ACCESS_KEY=minio12345
+      - CLOUDFLARE_R2_BUCKET=puppy
     ports:
       - "8002:8002"
+    depends_on:
+      - minio
+      - createbuckets
 
   engine:
     build:
@@ -115,3 +144,4 @@ services:
 
 volumes:
   postgres_data:
+  minio_data:


### PR DESCRIPTION
## Summary
- Switch to container-to-container networking for Engine/Flow
- Add Usersystem/API/Postgres services for local full-stack
- Introduce MinIO and set PuppyStorage to remote mode to avoid local FS writes

## Details
- engine: uses STORAGE_SERVER_URL=http://storage:8002 and USER_SYSTEM_URL=http://usersystem:8000
- flow: uses API_SERVER_URL=http://api:8004; PUPPYENGINE_URL=http://engine:8001
- usersystem/api: connect to local postgres service (db)
- storage: DEPLOYMENT_TYPE=remote; S3-compatible via MinIO (9000/9001)

## Test plan
- docker compose up -d --build
- Verify:
  - http://localhost:4000 (Flow UI)
  - http://localhost:8001/health (Engine)
  - http://localhost:8002/multipart/health (Storage)
  - http://localhost:8000/docs (UserSystem)
  - http://localhost:8004/docs (API)
  - http://localhost:9001 (MinIO console; user=minio, pass=minio12345)

## Notes
- If you prefer local FS for storage, set DEPLOYMENT_TYPE=local and mount ./local_storage