### PR TITLE
Fix two MCP transport bugs found in live qubits testing

### DIFF
--- a/backend/mcp_service/rpc/client.py
+++ b/backend/mcp_service/rpc/client.py
@@ -140,8 +140,16 @@ class InternalApiClient:
         )
         if response.status_code >= 400:
             try:
-                detail = response.json().get("detail")
+                body = response.json()
             except ValueError:
+                body = None
+            if isinstance(body, dict):
+                # The main API wraps errors as {code, message, data:{code,message}}
+                # (its ApiResponse envelope); older/raw FastAPI uses {detail:...}.
+                # Prefer the structured scoped-fs detail so the tool error code +
+                # message reach the client instead of a bare "null".
+                detail = body.get("data") or body.get("detail") or body.get("message") or body
+            else:
                 detail = response.text
             return {
                 "isError": True,

--- a/backend/mcp_service/server.py
+++ b/backend/mcp_service/server.py
@@ -471,15 +471,18 @@ def build_starlette_app(*, json_response: bool = True) -> Starlette:
             if config.get("mode") == "mcp_endpoint":
                 result = await rpc_client.call_mcp_runtime_tool(api_key, name, arguments or {})
                 if result.get("isError"):
+                    # Render the structured error detail; never let a missing
+                    # detail collapse to the literal "null" (carry the status at
+                    # minimum so the client gets something actionable).
+                    err = result.get("error")
+                    if err is None:
+                        err = {"message": "tool call failed",
+                               "status_code": result.get("status_code")}
                     return mcp_types.CallToolResult(
                         content=[
                             mcp_types.TextContent(
                                 type="text",
-                                text=json.dumps(
-                                    result.get("error", result),
-                                    ensure_ascii=False,
-                                    indent=2,
-                                ),
+                                text=json.dumps(err, ensure_ascii=False, indent=2),
                             )
                         ],
                         isError=True,

--- a/backend/src/connectors/agent/mcp/router.py
+++ b/backend/src/connectors/agent/mcp/router.py
@@ -309,7 +309,13 @@ async def proxy_mcp_server(
                     await client.aclose()
 
             return StreamingResponse(
-                upstream_response.aiter_raw(),
+                # aiter_bytes() (not aiter_raw()) so httpx transparently decodes
+                # any Content-Encoding (e.g. gzip) from the upstream. _filter_
+                # response_headers drops content-encoding, so forwarding the raw
+                # compressed bytes here would leave clients unable to decode the
+                # body — which broke tools/list and every large tool result for
+                # real MCP clients (initialize is small enough to go uncompressed).
+                upstream_response.aiter_bytes(),
                 status_code=upstream_response.status_code,
                 headers=response_headers,
                 media_type=media_type,


### PR DESCRIPTION
Both surfaced when driving the real MCP protocol end-to-end through the public proxy against the deployed stack (the scoped_fs logic itself was correct).

1. Proxy stripped Content-Encoding on the SSE path. Real StreamableHTTP clients send `Accept: text/event-stream`, so they take the SSE branch, which forwarded `upstream_response.aiter_raw()` (still gzip-compressed) while _filter_response_headers drops content-encoding. Clients received compressed bytes with no decode signal -> tools/list and every large tool result were undecodable (initialize worked only because it is small/uncompressed). Switched to aiter_bytes() so httpx transparently decodes the upstream encoding, matching the already-correct non-SSE path.

2. Tool error detail was lost as the literal "null". rpc_client.call_mcp_runtime_tool parsed `response.json().get("detail")`, but the main API wraps errors in its ApiResponse envelope `{code, message, data:{code,message}}` (no `detail` key), so error became None and call_tool rendered json.dumps(None) == "null". Now parses data/detail/message in order, and call_tool no longer collapses a missing detail to "null".

Live validation (qubits): all 21 e2e checks pass -- connect flow (one-time key + server_url), Bearer-only auth (X-API-KEY -> 401), initialize/tools-list, fs_write commits, fs_grep on a NON-ROOT scope (count=1), exclusion hides + denies direct cat + skips grep + blocks write-extension bypass, fs_cat-on-folder errors.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
