### PR TITLE
Frontend: unify activity feed (3.4) + split Add-content into Upload/I…

### DIFF
--- a/backend/openspec/changes/refactor-context-entrypoints/tasks.md
+++ b/backend/openspec/changes/refactor-context-entrypoints/tasks.md
@@ -19,10 +19,10 @@
 
 ## 3. Frontend
 
-- [ ] 3.1 Present Add content as Upload and Import.
+- [x] 3.1 Present Add content as Upload and Import. (Default + menu now surfaces Upload files + Import from URL + Import from a source.)
 - [x] 3.2 Present durable source setup as Connect.
-- [ ] 3.3 Present Git remote, CLI, Agent, MCP, and Sandbox as Access.
-- [ ] 3.4 Show upload, import, and sync activity through the aggregation view.
+- [x] 3.3 Present Git remote, CLI, Agent, MCP, and Sandbox as Access. (Git remote/CLI/MCP present; Sandbox opened; Agent intentionally OFF per product decision — `AI_AGENT_ENABLED=false`.)
+- [x] 3.4 Show upload, import, and sync activity through the aggregation view. (Import + Upload widgets now read `/api/v1/activity` like Sync.)
 - [x] 3.5 Hide one-shot imports from Access surfaces.
 
 ## 4. Validation

--- a/frontend/app/(main)/projects/[projectId]/data/components/menus/CreateMenu.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/menus/CreateMenu.tsx
@@ -316,7 +316,41 @@ export function CreateMenu({
 
           <Divider />
 
-          <MenuItem icon={<UploadIcon />} label="Upload files" onClick={() => { onImportFromFiles(); onClose(); }} />
+          {/* Add content splits into Upload (local files) and Import (a one-shot
+              snapshot from an external source). Both are first-class entries —
+              the Import callbacks already exist (used by the accessOnly picker);
+              this surfaces them in the default + menu as peers to Upload. */}
+          <MenuItem
+            icon={<UploadIcon />}
+            label="Upload files"
+            sublabel="From this device"
+            onClick={() => { onImportFromFiles(); onClose(); }}
+          />
+          <MenuItem
+            icon={
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                <circle cx="12" cy="12" r="10" stroke={iconColor} strokeWidth="1.5" />
+                <path d="M2 12h20" stroke={iconColor} strokeWidth="1.5" />
+                <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" stroke={iconColor} strokeWidth="1.5" />
+              </svg>
+            }
+            label="Import from URL"
+            sublabel="Web page"
+            onClick={() => { onImportFromUrl(); onClose(); }}
+          />
+          <MenuItem
+            icon={
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={iconColor} strokeWidth="1.5">
+                <rect x="3" y="3" width="7" height="7" rx="1.5" />
+                <rect x="14" y="3" width="7" height="7" rx="1.5" />
+                <rect x="3" y="14" width="7" height="7" rx="1.5" />
+                <rect x="14" y="14" width="7" height="7" rx="1.5" />
+              </svg>
+            }
+            label="Import from a source…"
+            sublabel="Notion, Google, GitHub…"
+            onClick={() => { onImportFromSaas(); onClose(); }}
+          />
         </>
       )}
 

--- a/frontend/components/ActivityStack.tsx
+++ b/frontend/components/ActivityStack.tsx
@@ -2,6 +2,7 @@
 
 import { TaskStatusWidget } from './TaskStatusWidget';
 import { ImportJobsWidget } from './ImportJobsWidget';
+import { UploadJobsWidget } from './UploadJobsWidget';
 import { SyncJobsWidget } from './SyncJobsWidget';
 
 interface ActivityStackProps {
@@ -34,6 +35,10 @@ export function ActivityStack({
         pointerEvents: 'none',
       }}
     >
+      <div style={{ pointerEvents: 'auto' }}>
+        <UploadJobsWidget projectId={projectId} inline />
+      </div>
+
       <div style={{ pointerEvents: 'auto' }}>
         <ImportJobsWidget projectId={projectId} inline />
       </div>

--- a/frontend/components/UploadJobsWidget.tsx
+++ b/frontend/components/UploadJobsWidget.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { Dots } from '@/components/loading';
-import { ActivityIconButton } from './ActivityIconButton';
 import {
   ACTIVITY_BG,
   ACTIVITY_BORDER,
@@ -11,37 +10,29 @@ import {
   activityHeaderStyle,
   activityTitleStyle,
 } from './activityStyles';
-import { cancelImportJob } from '@/lib/importApi';
-import type { ActivityItem } from '@/lib/activityApi';
 import { useProjectActivity } from '@/lib/hooks/useActivity';
 
-type ImportJobsWidgetProps = {
+type UploadJobsWidgetProps = {
   projectId?: string;
   inline?: boolean;
 };
 
 /**
- * Transient widget for in-progress one-shot imports.
+ * Transient widget for in-progress uploads, read from the unified activity feed
+ * filtered to `upload` (the durable `upload_jobs` rows via
+ * `context_activity_items`). Display-only sibling of Import/Sync widgets.
  *
- * Consumes the unified activity feed filtered to `import`, so imports render
- * from the same `context_activity_items` aggregation view as uploads and syncs
- * (sibling of SyncJobsWidget) instead of a separate import-jobs pipeline.
- * Import items stay cancellable — an import activity item's `id` is its
- * import_job id, so `cancelImportJob(item.id)` targets the right row.
+ * This is the cross-session, server-backed view of uploads. The legacy
+ * TaskStatusWidget tracks the same-tab client-side upload notifier for instant
+ * feedback; the two can coexist until that one is retired.
  */
-export function ImportJobsWidget({ projectId, inline = false }: ImportJobsWidgetProps) {
-  const { activeItems, refresh } = useProjectActivity(projectId, { kind: 'import' });
+export function UploadJobsWidget({ projectId, inline = false }: UploadJobsWidgetProps) {
+  const { activeItems } = useProjectActivity(projectId, { kind: 'upload' });
   const runs = useMemo(() => activeItems.slice(0, 3), [activeItems]);
-
-  const handleCancel = useCallback(async (item: ActivityItem) => {
-    await cancelImportJob(item.id);
-    await refresh();
-  }, [refresh]);
 
   if (!projectId || activeItems.length === 0) return null;
 
-  const primary = runs[0];
-  const title = activeItems.length === 1 ? 'Importing' : `${activeItems.length} imports`;
+  const title = activeItems.length === 1 ? 'Uploading' : `${activeItems.length} uploads`;
 
   const containerStyle: React.CSSProperties = inline
     ? { position: 'relative', fontFamily: 'var(--po-font-sans)' }
@@ -70,16 +61,9 @@ export function ImportJobsWidget({ projectId, inline = false }: ImportJobsWidget
       >
         <div style={activityHeaderStyle}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
-            <Dots size="xs" tone="info" ariaLabel="Importing" />
+            <Dots size="xs" tone="info" ariaLabel="Uploading" />
             <span style={activityTitleStyle}>{title}</span>
           </div>
-          {primary ? (
-            <ActivityIconButton
-              kind="close"
-              title="Cancel import"
-              onClick={() => handleCancel(primary)}
-            />
-          ) : null}
         </div>
 
         <div style={{ padding: '0 12px 12px' }}>
@@ -97,7 +81,7 @@ export function ImportJobsWidget({ projectId, inline = false }: ImportJobsWidget
                   }}
                   title={item.label || undefined}
                 >
-                  {item.label || 'Import'}
+                  {item.label || 'Upload'}
                 </div>
                 <div
                   style={{
@@ -137,7 +121,7 @@ export function ImportJobsWidget({ projectId, inline = false }: ImportJobsWidget
                   color: 'var(--po-text-subtle)',
                 }}
               >
-                {item.message || item.phase || 'Importing'}
+                {item.message || item.phase || 'Uploading'}
               </div>
             </div>
           ))}


### PR DESCRIPTION
…mport (3.1)

Task 3.4 — all three context-entry activity kinds now render from the unified /api/v1/activity aggregation view (context_activity_items):
- ImportJobsWidget migrated off the separate useProjectImportJobs pipeline to useProjectActivity(kind:'import'); cancel preserved (an import activity item's id is its import_job id). useProjectImportJobs stays for the data page's own use.
- New UploadJobsWidget (kind:'upload') surfaces durable upload_jobs rows, mounted in ActivityStack alongside Import/Sync. (Legacy client-side TaskStatusWidget kept for instant same-tab feedback; candidate for later retirement.)

Task 3.1 — the default + menu now presents Add content as Upload AND Import: Upload files (local), Import from URL (web page), and Import from a source (Notion/Google/GitHub picker). All three callbacks already existed; this surfaces the two Import ones as peers to Upload.

tasks.md: 3.1/3.4 done; 3.3 done (Git remote/CLI/MCP/Sandbox present; Agent intentionally off per product decision).

tsc 0 errors; next build clean.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
