### PR TITLE
fix(connections): label each connection's provider with its own kind

### DIFF
--- a/backend/src/connectors/manager/router.py
+++ b/backend/src/connectors/manager/router.py
@@ -181,6 +181,7 @@ def _enrich(rows: list[dict], sb_client) -> list[ConnectionOut]:
             "row": r,
             "cfg": cfg,
             "scope": scope,
+            "kind": kind,
             "base_name": base_name,
             "node_path": node_path,
             "node_name": node_name,
@@ -212,7 +213,7 @@ def _enrich(rows: list[dict], sb_client) -> list[ConnectionOut]:
         out.append(ConnectionOut(
             id=r["id"],
             project_id=r["project_id"],
-            provider=kind,
+            provider=e["kind"],
             name=name,
             path=node_path or None,
             node_name=e["node_name"],


### PR DESCRIPTION
_enrich() bound `kind` as a per-row loop variable in the first pass but never stored it per-entry, so the second pass labeled every ConnectionOut.provider with the LAST raw row's kind. The connections list (multi-row) therefore mislabeled every connection as whatever surface was created last (e.g. all "mcp"); single-row get_connection was unaffected (no staleness). Store kind per entry and use it.

Found during Tier-3 deep testing — verified _enrich now labels [git_remote, cli, mcp] rows correctly (previously all "mcp").

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
