### PR TITLE
fix(audit): analytics end-to-end + ISSUE-006 / ISSUE-003 / ISSUE-015

### DIFF
--- a/backend/scripts/backfill_scope_access_key_hash.py
+++ b/backend/scripts/backfill_scope_access_key_hash.py
@@ -1,0 +1,60 @@
+"""Backfill repo_scopes.access_key_hash from plaintext access_key (ISSUE-003).
+
+Idempotent: only touches rows that have an access_key but no access_key_hash.
+Run AFTER migration 20260704000000_repo_scopes_access_key_hash.sql and BEFORE
+enabling SCOPE_ACCESS_KEY_HASH_LOOKUP.
+
+Usage:
+    python -m scripts.backfill_scope_access_key_hash            # dry run
+    python -m scripts.backfill_scope_access_key_hash --apply    # write hashes
+"""
+
+from __future__ import annotations
+
+import sys
+
+from src.infra.supabase.client import SupabaseClient
+from src.repo.access_credentials import access_token_hash
+
+
+def backfill(apply: bool) -> None:
+    client = SupabaseClient().client
+    page = 0
+    page_size = 500
+    scanned = updated = 0
+
+    while True:
+        resp = (
+            client.table("repo_scopes")
+            .select("id, access_key, access_key_hash")
+            .not_.is_("access_key", "null")
+            .is_("access_key_hash", "null")
+            .range(page * page_size, page * page_size + page_size - 1)
+            .execute()
+        )
+        rows = resp.data or []
+        if not rows:
+            break
+        for row in rows:
+            scanned += 1
+            key = row.get("access_key")
+            if not key:
+                continue
+            digest = access_token_hash(key)
+            if apply:
+                client.table("repo_scopes").update(
+                    {"access_key_hash": digest}
+                ).eq("id", row["id"]).execute()
+            updated += 1
+        if len(rows) < page_size:
+            break
+        page += 1
+
+    verb = "updated" if apply else "would update"
+    print(f"[backfill] scanned={scanned} {verb}={updated}")
+    if not apply:
+        print("[backfill] dry run — re-run with --apply to write hashes")
+
+
+if __name__ == "__main__":
+    backfill(apply="--apply" in sys.argv[1:])

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -192,6 +192,17 @@ class Settings(BaseSettings):
     # Bound MCP token lifetime (ISSUE-007). MCP tokens previously carried no
     # `exp` claim and never expired. 0 disables expiry (legacy behaviour).
     MCP_TOKEN_TTL_SECONDS: int = 30 * 24 * 60 * 60  # 30 days
+    # Cluster-aware version notifications (ISSUE-015). When set, WebSocket
+    # commit_update events are fanned out across replicas via Redis pub/sub.
+    # Empty (default) = process-local fan-out only (unchanged behaviour).
+    NOTIFICATIONS_REDIS_URL: str = ""
+
+    # Scope access-key hashing (ISSUE-003). When enabled, repo_scopes writes and
+    # resolves keys via an HMAC hash (access_key_hash column) instead of trusting
+    # the plaintext column. OFF by default so behaviour is unchanged until ops has
+    # (1) applied the access_key_hash migration and (2) backfilled existing rows;
+    # then flip this on, and finally drop the plaintext access_key column.
+    SCOPE_ACCESS_KEY_HASH_LOOKUP: bool = False
 
     # Anthropic configuration
     ANTHROPIC_API_KEY: str = ""

--- a/backend/src/connectors/agent/service.py
+++ b/backend/src/connectors/agent/service.py
@@ -637,6 +637,7 @@ class AgentService:
                         user_id=current_user.user_id if current_user else None,
                         agent_id=request.agent_id,
                         session_id=request.session_id,
+                        project_id=_agent_project_id,
                     )
 
                     # Record path mapping (for write-back and display)

--- a/backend/src/platform/analytics/router.py
+++ b/backend/src/platform/analytics/router.py
@@ -55,7 +55,7 @@ async def get_access_timeseries(
     interval: str = Query("hour", description="'hour' or 'day'"),
     range_hours: int = Query(168, ge=1, le=_MAX_RANGE_HOURS, description="Hours back (default 7 days)"),
     agent_id: str | None = Query(None),
-    path: str | None = Query(None),
+    node_name: str | None = Query(None),
     current_user: CurrentUser = Depends(get_current_user),
 ):
     """
@@ -70,16 +70,18 @@ async def get_access_timeseries(
     now = datetime.utcnow()
     start_time = now - timedelta(hours=range_hours)
 
+    # access_logs identifies the accessed node by node_name (there is no "path"
+    # column in the current schema).
     query = supabase.table("access_logs") \
-        .select("id, created_at, agent_id, path") \
+        .select("id, created_at, agent_id, node_name") \
         .eq("project_id", project_id) \
         .gte("created_at", start_time.isoformat()) \
         .order("created_at", desc=False)
 
     if agent_id:
         query = query.eq("agent_id", agent_id)
-    if path:
-        query = query.eq("path", path)
+    if node_name:
+        query = query.eq("node_name", node_name)
 
     result = query.execute()
     logs = result.data or []
@@ -134,7 +136,7 @@ async def get_access_summary(
     start_time = datetime.utcnow() - timedelta(hours=range_hours)
 
     result = supabase.table("access_logs") \
-        .select("agent_id, path") \
+        .select("agent_id, node_name") \
         .eq("project_id", project_id) \
         .gte("created_at", start_time.isoformat()) \
         .execute()
@@ -142,7 +144,7 @@ async def get_access_summary(
     logs = result.data or []
 
     unique_agents = len({log["agent_id"] for log in logs if log.get("agent_id")})
-    unique_nodes = len({log["path"] for log in logs if log.get("path")})
+    unique_nodes = len({log["node_name"] for log in logs if log.get("node_name")})
 
     return {
         "total_accesses": len(logs),

--- a/backend/src/platform/analytics/service.py
+++ b/backend/src/platform/analytics/service.py
@@ -183,10 +183,12 @@ def log_context_access(
     try:
         supabase = get_supabase_client()
 
+        # NOTE: access_logs has no "path" column (schema uses node_name); inserting
+        # "path" previously made every write fail silently in the except below.
+        # The accessed-node identifier lands in node_name (falling back to path).
         supabase.table("access_logs").insert({
-            "path": path,
             "node_type": node_type,
-            "node_name": node_name,
+            "node_name": node_name or path,
             "user_id": user_id,
             "agent_id": agent_id,
             "session_id": session_id,

--- a/backend/src/platform/auth/router.py
+++ b/backend/src/platform/auth/router.py
@@ -44,6 +44,36 @@ def _rate_limit_check_email(ip: str) -> None:
     window.append(now)
 
 
+# ── Generic per-IP sliding-window limiter for sensitive auth endpoints (ISSUE-006) ──
+# NOTE: process-local — under multi-replica the effective limit is per-replica. This is
+# an app-layer defence-in-depth backstop (Supabase also throttles); a Redis-backed limiter
+# is the full fix. Fail-open by construction: it never depends on external infrastructure.
+_LOGIN_WINDOW = 300       # 5 minutes
+_LOGIN_MAX_HITS = 10      # brute-force / credential-stuffing backstop, generous for real users
+_REFRESH_WINDOW = 60
+_REFRESH_MAX_HITS = 30
+_rate_hits: dict[tuple[str, str], list[float]] = defaultdict(list)
+
+
+def _client_ip(request: Request) -> str:
+    return request.client.host if request and request.client else "unknown"
+
+
+def _rate_limit(bucket: str, ip: str, *, max_hits: int, window_s: float) -> None:
+    """Raise 429 (with Retry-After) if (bucket, ip) exceeded max_hits in window_s."""
+    now = time.monotonic()
+    key = (bucket, ip)
+    kept = [t for t in _rate_hits[key] if now - t < window_s]
+    _rate_hits[key] = kept
+    if len(kept) >= max_hits:
+        raise HTTPException(
+            status_code=429,
+            detail="Too many requests. Please try again later.",
+            headers={"Retry-After": str(int(window_s))},
+        )
+    kept.append(now)
+
+
 class LoginRequest(BaseModel):
     email: str
     password: str
@@ -145,7 +175,8 @@ async def check_email(body: CheckEmailRequest, request: Request):
 
 
 @router.post("/login", response_model=ApiResponse[LoginResponse])
-def login(body: LoginRequest):
+def login(body: LoginRequest, request: Request):
+    _rate_limit("login", _client_ip(request), max_hits=_LOGIN_MAX_HITS, window_s=_LOGIN_WINDOW)
     try:
         auth_client = _make_auth_client()
         result = auth_client.auth.sign_in_with_password({
@@ -174,7 +205,8 @@ def login(body: LoginRequest):
 
 
 @router.post("/refresh", response_model=ApiResponse[LoginResponse])
-def refresh_token(body: RefreshRequest):
+def refresh_token(body: RefreshRequest, request: Request):
+    _rate_limit("refresh", _client_ip(request), max_hits=_REFRESH_MAX_HITS, window_s=_REFRESH_WINDOW)
     try:
         auth_client = _make_auth_client()
         result = auth_client.auth.refresh_session(body.refresh_token)

--- a/backend/src/repo/scope_repository.py
+++ b/backend/src/repo/scope_repository.py
@@ -70,7 +70,29 @@ class RepoScopeRepository:
         return _row_to_scope(rows[0]) if rows else None
 
     def get_by_access_key(self, access_key: str) -> Optional[RepoScope]:
-        """Hot path: access-key auth resolves an access_key to its scope."""
+        """Hot path: access-key auth resolves an access_key to its scope.
+
+        When SCOPE_ACCESS_KEY_HASH_LOOKUP is enabled (ISSUE-003) we resolve by
+        HMAC hash first, then fall back to the plaintext column for rows not yet
+        backfilled. With the flag off, behaviour is exactly the plaintext lookup.
+        """
+        from src.config import settings
+
+        if settings.SCOPE_ACCESS_KEY_HASH_LOOKUP:
+            from src.repo.access_credentials import access_token_hash
+            resp = (
+                self._client.table(self.TABLE)
+                .select("*")
+                .eq("access_key_hash", access_token_hash(access_key))
+                .is_("access_key_revoked_at", "null")
+                .limit(1)
+                .execute()
+            )
+            rows = resp.data or []
+            if rows:
+                return _row_to_scope(rows[0])
+            # fall through: row may predate the backfill and only have plaintext
+
         resp = (
             self._client.table(self.TABLE)
             .select("*")
@@ -129,19 +151,20 @@ class RepoScopeRepository:
     ) -> RepoScope:
         """Insert a new scope. Access surfaces are created explicitly by
         ScopeService after this row is persisted."""
-        resp = (
-            self._client.table(self.TABLE)
-            .insert({
-                "project_id": project_id,
-                "name": name,
-                "path": path,
-                "exclude": exclude,
-                "mode": mode,
-                "is_root": is_root,
-                "access_key": access_key,
-            })
-            .execute()
-        )
+        row: dict[str, Any] = {
+            "project_id": project_id,
+            "name": name,
+            "path": path,
+            "exclude": exclude,
+            "mode": mode,
+            "is_root": is_root,
+            "access_key": access_key,
+        }
+        from src.config import settings
+        if settings.SCOPE_ACCESS_KEY_HASH_LOOKUP:
+            from src.repo.access_credentials import access_token_hash
+            row["access_key_hash"] = access_token_hash(access_key)
+        resp = self._client.table(self.TABLE).insert(row).execute()
         return _row_to_scope(resp.data[0])
 
     def update(
@@ -173,12 +196,17 @@ class RepoScopeRepository:
     def regenerate_access_key(self, scope_id: str, new_key: str) -> bool:
         """Atomic: mark old key revoked AND set new key. We reuse the same
         column (no separate history table) so old-key auth fails immediately."""
+        patch: dict[str, Any] = {
+            "access_key": new_key,
+            "access_key_revoked_at": None,
+        }
+        from src.config import settings
+        if settings.SCOPE_ACCESS_KEY_HASH_LOOKUP:
+            from src.repo.access_credentials import access_token_hash
+            patch["access_key_hash"] = access_token_hash(new_key)
         resp = (
             self._client.table(self.TABLE)
-            .update({
-                "access_key": new_key,
-                "access_key_revoked_at": None,
-            })
+            .update(patch)
             .eq("id", scope_id)
             .execute()
         )

--- a/backend/src/version_engine/derived/notifications.py
+++ b/backend/src/version_engine/derived/notifications.py
@@ -24,6 +24,8 @@ normal version refresh/fetch covers the rest.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
 import uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -32,6 +34,9 @@ from datetime import datetime, timezone
 from fastapi import WebSocket
 
 from src.utils.logger import log_debug, log_info, log_warning
+
+# Redis channel for cross-replica commit_update fan-out (ISSUE-015).
+_PUBSUB_CHANNEL = "puppyone:version_notifications"
 
 
 @dataclass
@@ -68,6 +73,12 @@ class NotificationManager:
         # against the iteration in broadcast which would otherwise
         # race a concurrent unregister.
         self._lock = asyncio.Lock()
+        # Cross-replica pub/sub (ISSUE-015). Disabled unless NOTIFICATIONS_REDIS_URL
+        # is set; origin id lets a replica ignore the events it published itself.
+        self._origin_id = uuid.uuid4().hex
+        self._redis = None
+        self._pubsub_task: asyncio.Task | None = None
+        self._pubsub_started = False
 
     @classmethod
     def get(cls) -> "NotificationManager":
@@ -85,6 +96,7 @@ class NotificationManager:
         self, websocket: WebSocket, project_id: str,
         scope_path: str, agent: str,
     ) -> _ClientConn:
+        await self._ensure_pubsub_started()
         scope_norm = (scope_path or "").strip("/")
         conn = _ClientConn(
             websocket=websocket, project_id=project_id,
@@ -149,6 +161,27 @@ class NotificationManager:
             "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         }
 
+        await self._ensure_pubsub_started()
+        # Fan out to this replica's own connections...
+        await self._local_broadcast(
+            project_id, scope_norm, payload,
+            pushed_by=pushed_by, pusher_client_id=pusher_client_id,
+        )
+        # ...and to other replicas via Redis (no-op when pub/sub is disabled).
+        await self._publish({
+            "origin": self._origin_id,
+            "project_id": project_id,
+            "scope_norm": scope_norm,
+            "payload": payload,
+            "pushed_by": pushed_by,
+            "pusher_client_id": pusher_client_id,
+        })
+
+    async def _local_broadcast(
+        self, project_id: str, scope_norm: str, payload: dict, *,
+        pushed_by: str, pusher_client_id: str,
+    ) -> None:
+        """Fan a prepared commit_update payload out to THIS replica's clients."""
         # Targets: every connection on the same project whose scope
         # contains the affected path. ``''`` (root scope) is the
         # ancestor of everything.
@@ -182,6 +215,73 @@ class NotificationManager:
                 f"project={project_id} scope={scope_norm!r} "
                 f"sent={sent} dropped={dropped}"
             )
+
+    # ── cross-replica pub/sub (ISSUE-015) ──────────────
+
+    async def _ensure_pubsub_started(self) -> None:
+        """Lazily connect Redis + start the subscriber. Fail-open: any error
+        degrades to process-local fan-out (the pre-ISSUE-015 behaviour)."""
+        if self._pubsub_started:
+            return
+        self._pubsub_started = True  # only attempt once
+        from src.config import settings
+        url = getattr(settings, "NOTIFICATIONS_REDIS_URL", "") or ""
+        if not url:
+            return
+        try:
+            import redis.asyncio as aioredis
+            self._redis = aioredis.from_url(url, encoding="utf-8", decode_responses=True)
+            self._pubsub_task = asyncio.create_task(self._subscriber_loop())
+            log_info("[NotificationManager] cross-replica pub/sub enabled")
+        except Exception as e:  # noqa: BLE001 — never break notifications on redis issues
+            log_warning(f"[NotificationManager] pub/sub disabled (init failed): {e}")
+            self._redis = None
+
+    async def _publish(self, routing: dict) -> None:
+        if not self._redis:
+            return
+        try:
+            await self._redis.publish(_PUBSUB_CHANNEL, json.dumps(routing))
+        except Exception as e:  # noqa: BLE001 — local fan-out already happened
+            log_warning(f"[NotificationManager] publish failed (local-only): {e}")
+
+    async def _subscriber_loop(self) -> None:
+        """Receive commit_updates published by OTHER replicas and fan them out
+        to this replica's local connections. Own-origin events are skipped."""
+        try:
+            pubsub = self._redis.pubsub()
+            await pubsub.subscribe(_PUBSUB_CHANNEL)
+            async for message in pubsub.listen():
+                if message.get("type") != "message":
+                    continue
+                try:
+                    data = json.loads(message["data"])
+                except Exception:  # noqa: BLE001
+                    continue
+                if data.get("origin") == self._origin_id:
+                    continue  # already fanned out locally by this replica
+                await self._local_broadcast(
+                    data.get("project_id", ""), data.get("scope_norm", ""),
+                    data.get("payload", {}),
+                    pushed_by=data.get("pushed_by", ""),
+                    pusher_client_id=data.get("pusher_client_id", ""),
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001
+            log_warning(f"[NotificationManager] subscriber loop ended: {e}")
+
+    async def stop_pubsub(self) -> None:
+        """Cancel the subscriber + close Redis (call on app shutdown)."""
+        if self._pubsub_task:
+            self._pubsub_task.cancel()
+            with contextlib.suppress(Exception):
+                await self._pubsub_task
+            self._pubsub_task = None
+        if self._redis:
+            with contextlib.suppress(Exception):
+                await self._redis.aclose()
+            self._redis = None
 
     def _enqueue_offline(self, client_id: str, payload: dict):
         q = self._offline[client_id]

--- a/backend/src/version_engine/infrastructure/supabase/scope_repository.py
+++ b/backend/src/version_engine/infrastructure/supabase/scope_repository.py
@@ -34,11 +34,27 @@ def find_scope_by_access_key(
     ``None`` when the key is unknown; callers translate that to a 401.
     """
     try:
+        from src.config import settings
+
+        select_cols = "id, project_id, path, exclude, mode, access_key_revoked_at"
+        if settings.SCOPE_ACCESS_KEY_HASH_LOOKUP:
+            # ISSUE-003: resolve by HMAC hash first, then fall back to the
+            # plaintext column for rows not yet backfilled.
+            from src.repo.access_credentials import access_token_hash
+            resp = (
+                supabase.client.table("repo_scopes")
+                .select(select_cols)
+                .eq("access_key_hash", access_token_hash(access_key))
+                .limit(1)
+                .execute()
+            )
+            rows = safe_data(resp)
+            if rows:
+                return rows[0]
+
         resp = (
             supabase.client.table("repo_scopes")
-            .select(
-                "id, project_id, path, exclude, mode, access_key_revoked_at",
-            )
+            .select(select_cols)
             .eq("access_key", access_key)
             .limit(1)
             .execute()

--- a/backend/tests/security/test_audit_deferred_fixes.py
+++ b/backend/tests/security/test_audit_deferred_fixes.py
@@ -1,0 +1,154 @@
+"""Hermetic tests for the previously-deferred fixes: ISSUE-003 (scope access-key
+hashing, gated dual-read) and ISSUE-015 (cluster-aware notifications, gated).
+
+No Supabase, no Redis, no network — fake clients / websockets only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+
+# ── ISSUE-003: scope access-key hash lookup (gated dual-read) ───────────────
+
+class _FakeScopeClient:
+    """Chainable fake: returns a row only when an .eq() on a "hit" column runs."""
+
+    def __init__(self, hit_columns):
+        self.hit_columns = set(hit_columns)
+        self.eq_calls: list[tuple] = []
+        self._last_eq_col = None
+
+    @property
+    def client(self):
+        return self
+
+    def table(self, _name):
+        return self
+
+    def select(self, *a, **k):
+        return self
+
+    def eq(self, col, val):
+        self.eq_calls.append((col, val))
+        self._last_eq_col = col
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def is_(self, *a, **k):
+        return self
+
+    def execute(self):
+        row = {
+            "id": "s1", "project_id": "p1", "path": "docs",
+            "exclude": [], "mode": "rw", "access_key_revoked_at": None,
+        }
+        data = [row] if self._last_eq_col in self.hit_columns else []
+        return SimpleNamespace(data=data)
+
+
+def _find():
+    from src.version_engine.infrastructure.supabase import scope_repository
+    return scope_repository.find_scope_by_access_key
+
+
+def test_flag_off_uses_plaintext_only(monkeypatch):
+    from src.config import settings
+    monkeypatch.setattr(settings, "SCOPE_ACCESS_KEY_HASH_LOOKUP", False, raising=False)
+    client = _FakeScopeClient(hit_columns={"access_key"})
+    row = _find()(client, "cli_secretkey")
+    assert row is not None
+    cols = [c for c, _ in client.eq_calls]
+    assert "access_key" in cols
+    assert "access_key_hash" not in cols, "flag off must never touch the hash column"
+
+
+def test_flag_on_resolves_by_hash(monkeypatch):
+    from src.config import settings
+    from src.repo.access_credentials import access_token_hash
+    monkeypatch.setattr(settings, "SCOPE_ACCESS_KEY_HASH_LOOKUP", True, raising=False)
+    client = _FakeScopeClient(hit_columns={"access_key_hash"})
+    row = _find()(client, "cli_secretkey")
+    assert row is not None
+    # First lookup is by hash of the key, not the plaintext.
+    assert ("access_key_hash", access_token_hash("cli_secretkey")) in client.eq_calls
+
+
+def test_flag_on_falls_back_to_plaintext_for_unbackfilled_rows(monkeypatch):
+    from src.config import settings
+    monkeypatch.setattr(settings, "SCOPE_ACCESS_KEY_HASH_LOOKUP", True, raising=False)
+    # Hash lookup misses (row not backfilled); plaintext still resolves it.
+    client = _FakeScopeClient(hit_columns={"access_key"})
+    row = _find()(client, "cli_secretkey")
+    assert row is not None
+    cols = [c for c, _ in client.eq_calls]
+    assert "access_key_hash" in cols and "access_key" in cols
+
+
+# ── ISSUE-015: cluster-aware notifications (gated, fail-open) ────────────────
+
+class _FakeWS:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send_json(self, payload):
+        self.sent.append(payload)
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.published: list[tuple] = []
+
+    async def publish(self, channel, data):
+        self.published.append((channel, data))
+
+
+def _manager():
+    from src.version_engine.derived.notifications import NotificationManager
+    return NotificationManager()
+
+
+def test_local_fanout_delivers_to_subscribed_client():
+    async def main():
+        m = _manager()
+        ws = _FakeWS()
+        await m.register(ws, "p1", "docs", agent="agent-a")
+        await m.broadcast_commit_update(
+            "p1", "docs", commit_id="c1", pushed_by="someone-else", changes=[],
+        )
+        assert len(ws.sent) == 1
+        assert ws.sent[0]["type"] == "commit_update"
+        assert ws.sent[0]["commit_id"] == "c1"
+    asyncio.run(main())
+
+
+def test_pubsub_disabled_by_default():
+    async def main():
+        m = _manager()
+        await m._ensure_pubsub_started()
+        assert m._redis is None and m._pubsub_task is None
+    asyncio.run(main())
+
+
+def test_broadcast_publishes_with_origin_when_redis_present():
+    async def main():
+        import json
+        m = _manager()
+        m._pubsub_started = True          # skip real connect
+        m._redis = _FakeRedis()
+        await m.broadcast_commit_update(
+            "p1", "docs/sub", commit_id="c9", pushed_by="u", changes=[{"path": "a.md"}],
+        )
+        assert len(m._redis.published) == 1
+        _channel, raw = m._redis.published[0]
+        msg = json.loads(raw)
+        assert msg["origin"] == m._origin_id      # loop-prevention tag
+        assert msg["project_id"] == "p1"
+        assert msg["scope_norm"] == "docs/sub"
+        assert msg["payload"]["commit_id"] == "c9"
+    asyncio.run(main())

--- a/backend/tests/security/test_audit_rate_limit.py
+++ b/backend/tests/security/test_audit_rate_limit.py
@@ -1,0 +1,51 @@
+"""ISSUE-006 — sensitive auth endpoints are rate-limited (login/refresh).
+
+Hermetic: exercises the in-process limiter directly (no Supabase, no network).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+
+def _auth():
+    from src.platform.auth import router
+    return router
+
+
+def test_rate_limit_blocks_after_max_hits():
+    r = _auth()
+    r._rate_hits.clear()
+    ip = "203.0.113.7"
+    # First N allowed, N+1 blocked with 429 + Retry-After.
+    for _ in range(5):
+        r._rate_limit("unit-test", ip, max_hits=5, window_s=60)
+    with pytest.raises(HTTPException) as ei:
+        r._rate_limit("unit-test", ip, max_hits=5, window_s=60)
+    assert ei.value.status_code == 429
+    assert "Retry-After" in (ei.value.headers or {})
+
+
+def test_rate_limit_is_per_ip_and_per_bucket():
+    r = _auth()
+    r._rate_hits.clear()
+    # Exhaust one IP...
+    for _ in range(3):
+        r._rate_limit("login", "10.0.0.1", max_hits=3, window_s=60)
+    with pytest.raises(HTTPException):
+        r._rate_limit("login", "10.0.0.1", max_hits=3, window_s=60)
+    # ...a different IP is unaffected...
+    r._rate_limit("login", "10.0.0.2", max_hits=3, window_s=60)
+    # ...and a different bucket for the same IP is independent.
+    r._rate_limit("refresh", "10.0.0.1", max_hits=3, window_s=60)
+
+
+def test_login_and_refresh_are_wired_to_limiter():
+    """Guard against regressions: both sensitive endpoints must apply a limit."""
+    import inspect
+    r = _auth()
+    login_src = inspect.getsource(r.login)
+    refresh_src = inspect.getsource(r.refresh_token)
+    assert "_rate_limit(" in login_src, "login must be rate-limited (ISSUE-006)"
+    assert "_rate_limit(" in refresh_src, "refresh must be rate-limited (ISSUE-006)"

--- a/supabase/migrations/20260704000000_repo_scopes_access_key_hash.sql
+++ b/supabase/migrations/20260704000000_repo_scopes_access_key_hash.sql
@@ -1,0 +1,25 @@
+-- ISSUE-003: hash repo_scopes access keys at rest.
+--
+-- repo_scopes.access_key is the primary credential for Git / CLI / AP-FS access
+-- and was stored + queried in plaintext. This adds a nullable HMAC-hash column so
+-- the app can resolve keys by hash instead of trusting the plaintext column.
+--
+-- Staged, non-breaking rollout:
+--   1. Apply this migration (adds access_key_hash, nullable + indexed).
+--   2. Run scripts/backfill_scope_access_key_hash.py to populate hashes for
+--      existing rows.
+--   3. Set SCOPE_ACCESS_KEY_HASH_LOOKUP=true so writes populate the hash and
+--      reads resolve by hash (with plaintext fallback for any missed rows).
+--   4. In a LATER migration, once all rows are backfilled and callers no longer
+--      need the plaintext value, drop the access_key column.
+
+ALTER TABLE public.repo_scopes
+    ADD COLUMN IF NOT EXISTS access_key_hash text;
+
+CREATE INDEX IF NOT EXISTS idx_repo_scopes_access_key_hash
+    ON public.repo_scopes (access_key_hash)
+    WHERE access_key_hash IS NOT NULL;
+
+COMMENT ON COLUMN public.repo_scopes.access_key_hash IS
+    'HMAC-SHA256 of access_key (ISSUE-003). Populated by backfill + on mint when '
+    'SCOPE_ACCESS_KEY_HASH_LOOKUP is enabled. Replaces plaintext access_key lookups.';


### PR DESCRIPTION
Follow-up to "fix: issue lists" (the P0/P1 batch). Live-testing on qubits surfaced a pre-existing analytics bug and this finishes the remaining valid issues (excludes ISSUE-020 desktop signing = needs Apple certs, and ISSUE-022 web/desktop convergence = large refactor).

- ISSUE-001 (completion): member analytics 500'd because access_logs has no `path` column (schema uses node_name) and the write path inserted `path` (every write failed silently) without project_id. Read + write + caller now use node_name and populate project_id, so tenant-scoped analytics returns data.
- ISSUE-006: per-IP sliding-window limiter on login (10 / 5 min) and refresh (30 / min) with Retry-After; fail-open, in-process (Redis-backed = follow-up).
- ISSUE-003: repo_scopes access_key hashing — migration + gated dual-read + hash-on-mint + backfill script. OFF by default (SCOPE_ACCESS_KEY_HASH_LOOKUP) so it is non-breaking until ops migrates + backfills + enables, then drops the plaintext column.
- ISSUE-015: cluster-aware version notifications via Redis pub/sub with local fallback, gated on NOTIFICATIONS_REDIS_URL (empty = today's local-only fan-out).
- Tests: +9 hermetic (rate-limit, 003 dual-read, 015 pub/sub). 59 audit tests pass.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
