### PR TITLE
docs+chore(backend): fix AGENTS.md access-model drift (016) + drop de…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ It aggregates information scattered across various sources into a unified Contex
 
 - **Agent management** — Create agents, bind tools, control access scope, SSE streaming chat
 - **Full CLI coverage** — Every operation available via command line, enabling AI coding tools like Claude Code to drive the platform directly
-- **Unified access management** — All access types (sync/agent/MCP/sandbox/filesystem) consolidated into a single `access_points` table with a single entry point
+- **Unified access management** — All access surface types (Git remote/CLI/agent/MCP/sandbox) are served through a single `/api/v1/access` entry point, backed by the `access_surfaces` table (each row scope-bound to a `repo_scopes` row); external SaaS data sources live separately in the `connectors` table
 
 ## Active Development Directories
 
@@ -82,7 +82,7 @@ backend/
 │   ├── tool/                  # Tool registration & search index
 │   │
 │   ├── connectors/            # Access types
-│   │   ├── manager/           #   Unified access CRUD (connections table)
+│   │   ├── manager/           #   Access surface CRUD (access_surfaces table, scope-bound to repo_scopes)
 │   │   ├── datasource/        #   SaaS data source providers (Gmail/GitHub/Notion/...)
 │   │   │   ├── gmail/         #     Gmail connector
 │   │   │   ├── github/        #     GitHub connector
@@ -138,13 +138,13 @@ backend/
 - **Fully async**: All I/O operations use `async/await`
 - **Pydantic models**: All request/response defined with Pydantic schemas
 - **Naming conventions**: Files `snake_case.py`, classes `PascalCase`, functions/variables `snake_case`
-- **DB table naming**: New tables use **plural snake_case** (e.g. `projects`, `access_points`, `version_transactions`). Deferred physical legacy names may appear only through `backend/src/version_engine/server/db_names.py`.
+- **DB table naming**: New tables use **plural snake_case** (e.g. `projects`, `access_surfaces`, `version_transactions`). Deferred physical legacy names may appear only through `backend/src/version_engine/server/db_names.py`.
 - **Route prefix**: Business APIs under `/api/v1`, internal APIs under `/internal`
 - **Module structure**: Each module typically contains `router.py`, `service.py`, `repository.py`, `schemas.py`
 
 ### Database Tables
 
-All tables use plural snake_case names. The "unified access" architecture stores agents, MCP endpoints, sandbox endpoints, and sync access points in a single `access_points` base table differentiated by `provider`. Sync-specific state lives in the `sync_state` satellite table; agent-specific config in `agent_profiles`.
+All tables use plural snake_case names. The "unified access" architecture serves agents, MCP endpoints, sandbox endpoints, and Git-remote/CLI credentials through the `access_surfaces` table, differentiated by `kind` and each scope-bound to a `repo_scopes` row (scopes carry the `access_key`); provider-specific config is stored inline in each surface's `config` JSON column. External SaaS data-source integrations live separately in the `connectors` table.
 
 | Table | Repository | Description |
 |-------|-----------|-------------|
@@ -154,11 +154,11 @@ All tables use plural snake_case names. The "unified access" architecture stores
 | `org_members` | `organization/repository.py` | Organization membership |
 | `org_invitations` | `organization/repository.py` | Organization invitations |
 | `profiles` | `profile/repository.py` | User profiles |
-| `access_points` | `connectors/manager/router.py`, `connectors/agent/config/repository.py` | Unified access points (agents/MCP/sandbox/sync) — base table |
-| `sync_state` | _(satellite table)_ | Sync-specific state (direction, cursor, last_synced_at, etc.) |
-| `agent_profiles` | _(satellite table)_ | Agent-specific config (model, system_prompt, etc.) |
-| `access_permissions` | `connectors/agent/config/repository.py` | Access point ↔ content node permissions |
-| `access_tools` | `connectors/agent/config/repository.py`, `tool/service.py` | Access point ↔ tool bindings |
+| `access_surfaces` | `connectors/manager/router.py`, `repo/access_surface_repository.py` | Unified access surfaces (Git remote/CLI/agent/MCP/sandbox), keyed by `kind`, scope-bound to `repo_scopes` |
+| `repo_scopes` | `repo/scope_repository.py`, `repo/scope_service.py` | Scoped subtrees each access surface binds to (carries `access_key`) |
+| `connectors` | `repo/connector_repository.py`, `repo/connector_service.py` | External SaaS data-source integrations (Gmail/GitHub/Notion/...) |
+| `access_permissions` | `connectors/agent/config/repository.py` | Access surface ↔ content node permissions |
+| `access_tools` | `connectors/agent/config/repository.py`, `tool/service.py` | Access surface ↔ tool bindings |
 | `content_nodes` | _(dropped — replaced by Version Engine Git trees in object storage)_ | Legacy content tree |
 | `tools` | `supabase/tools/repository.py` | Registered tools |
 | `mcps` | `supabase/mcps/repository.py`, `supabase/mcp_v2/repository.py` | MCP server instances |

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -67,7 +67,7 @@ backend/
 │   ├── tool/                  # 工具注册 & 搜索索引
 │   │
 │   ├── connectors/            # 连接器
-│   │   ├── manager/           # 统一 Access CRUD (access_points 表)
+│   │   ├── manager/           # Access surface CRUD (access_surfaces 表, scope 绑定 repo_scopes)
 │   │   ├── agent/             # AI Agent (config/chat/MCP 绑定)
 │   │   ├── datasource/        # SaaS 数据源 (Gmail/GitHub/Notion/...)
 │   │   │   └── oauth/         # OAuth 授权流程 & token 存储

--- a/backend/src/infra/mcp_server/dependencies.py
+++ b/backend/src/infra/mcp_server/dependencies.py
@@ -1,12 +1,6 @@
-from fastapi import Depends, Path
 from src.config import settings
 from src.infra.mcp_server.repository import McpInstanceRepositoryJSON, McpInstanceRepositorySupabase
 from src.infra.mcp_server.service import McpService
-from src.infra.mcp_server.models import McpInstance
-from src.platform.auth.models import CurrentUser
-from src.platform.auth.dependencies import get_current_user
-from src.platform.project.dependencies import get_project_service
-from src.platform.project.service import ProjectService
 
 
 # Use a global variable to store the singleton instead of lru_cache
@@ -17,6 +11,14 @@ _mcp_service = None
 def get_mcp_instance_service() -> McpService:
     """
     Dependency injection factory for mcp_instance_service. Supports choosing storage strategy via configuration.
+
+    NOTE (ISSUE-017): the only live consumer is the /ready + /health readiness
+    probe, which calls McpService.check_mcp_server_health() — an HTTP /healthz call
+    to the external MCP server. The legacy per-instance api-key dependencies
+    (get_verified_mcp_instance / get_mcp_instance_by_api_key) were removed here
+    because no route mounted them; the remaining legacy `mcps`-table CRUD is now
+    unreachable and slated for removal (decouple the health probe from the instance
+    repo, then drop the plaintext-key `mcps` table via migration).
     """
     global _mcp_service
     if _mcp_service is None:
@@ -27,75 +29,3 @@ def get_mcp_instance_service() -> McpService:
         else:
             raise ValueError(f"Unsupported storage type: {settings.STORAGE_TYPE}")
     return _mcp_service
-
-
-async def get_verified_mcp_instance(
-    api_key: str = Path(..., description="API Key of the MCP instance"),
-    mcp_instance_service: McpService = Depends(get_mcp_instance_service),
-    current_user: CurrentUser = Depends(get_current_user),
-    project_service: ProjectService = Depends(get_project_service),
-) -> McpInstance:
-    """
-    Dependency injection function: Get and verify user's access to an MCP instance (project_id-based access)
-
-    This dependency automatically verifies:
-    1. Whether the MCP instance exists
-    2. Whether the user has access to the project the MCP instance belongs to
-
-    Raises NotFoundException if verification fails
-
-    Args:
-        api_key: API Key of the MCP instance (from path parameter)
-        mcp_instance_service: McpService instance (via dependency injection)
-        current_user: Current user (via dependency injection)
-        project_service: ProjectService instance (for verifying project access)
-
-    Returns:
-        Verified McpInstance object
-
-    Raises:
-        NotFoundException: If instance does not exist or user lacks permission
-    """
-    def verify_access(pid, uid):
-        return project_service.verify_project_access(pid, uid) is not None
-    return await mcp_instance_service.get_mcp_instance_by_api_key_with_access_check(
-        api_key, current_user.user_id, verify_access
-    )
-
-
-async def get_mcp_instance_by_api_key(
-    api_key: str = Path(..., description="API Key of the MCP instance"),
-    mcp_instance_service: McpService = Depends(get_mcp_instance_service),
-) -> McpInstance:
-    """
-    Dependency injection function: Only validates whether the API Key is valid, does not check user permissions
-
-    Used for proxy routes and other scenarios that don't require user login
-
-    This dependency only verifies:
-    1. Whether the MCP instance exists
-
-    Does not verify:
-    - User login status
-    - User ownership of the instance
-
-    Args:
-        api_key: API Key of the MCP instance (from path parameter)
-        mcp_instance_service: McpService instance (via dependency injection)
-
-    Returns:
-        McpInstance object
-
-    Raises:
-        NotFoundException: If instance does not exist
-    """
-    from src.exceptions import NotFoundException, ErrorCode
-
-    instance = await mcp_instance_service.get_mcp_instance_by_api_key(api_key)
-    if not instance:
-        raise NotFoundException(
-            f"MCP instance not found: api_key={api_key[:20]}...",
-            code=ErrorCode.MCP_INSTANCE_NOT_FOUND,
-        )
-
-    return instance


### PR DESCRIPTION
…ad legacy MCP deps (017)

ISSUE-016 (docs): the AGENTS.md files still described a dropped `access_points` base table (+ non-existent sync_state/agent_profiles satellites) as the unified access model. Rewrote the stale sections in root AGENTS.md and backend/AGENTS.md to the real schema: repo_scopes (scoped subtrees + access_key), access_surfaces (unified access rows keyed by kind, scope-bound to repo_scopes; served by connectors/manager/router.py), and connectors (external SaaS data sources). Verified: no remaining live `access_points` references; every table mentioned exists in supabase/migrations/.

ISSUE-017 (partial): removed the legacy per-instance MCP api-key dependencies (get_verified_mcp_instance, get_mcp_instance_by_api_key) — confirmed unmounted on any route (dead code on the plaintext-key `mcps` table). The only live consumer of mcp_server is the /ready + /health probe (an HTTP /healthz call that does NOT touch the `mcps` table). Fully dropping the table remains a scoped follow-up (decouple the health probe from the instance repo, then a drop migration).

Verified: python parse ok; pytest tests/security/ = 102 passed.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
