### PR TITLE
fix(ci): tolerate retired scope credential columns

### DIFF
--- a/backend/scripts/backfill_scope_access_key_hash.py
+++ b/backend/scripts/backfill_scope_access_key_hash.py
@@ -22,13 +22,14 @@ def _legacy_columns_have_been_retired(error: Exception) -> bool:
     """Only treat the expected PostgREST missing-column response as a no-op.
 
     The migration workflow deliberately runs this idempotent backfill before
-    every `db push`.  After the destructive migration has succeeded, querying
-    its dropped columns produces PGRST204. Do not hide network, auth, or other
-    database errors: they must still fail the deployment.
+    every `db push`. After the destructive migration has succeeded, querying
+    its dropped columns can produce PostgREST's PGRST204 or PostgreSQL's 42703
+    (depending on the API path). Do not hide network, auth, or other database
+    errors: they must still fail the deployment.
     """
     message = str(error).lower()
     return (
-        getattr(error, "code", None) == "PGRST204"
+        getattr(error, "code", None) in {"PGRST204", "42703"}
         and "repo_scopes" in message
         and ("access_key" in message or "access_key_hash" in message)
     )

--- a/backend/tests/security/test_credential_backfill_ci_contract.py
+++ b/backend/tests/security/test_credential_backfill_ci_contract.py
@@ -49,10 +49,16 @@ def test_scope_backfill_only_skips_the_expected_postgrest_retired_column_error()
     class PostgrestMissingColumn(Exception):
         code = "PGRST204"
 
+    class PostgresMissingColumn(Exception):
+        code = "42703"
+
     assert _legacy_columns_have_been_retired(
         PostgrestMissingColumn(
             "Could not find the 'access_key' column of 'repo_scopes' in the schema cache"
         )
+    )
+    assert _legacy_columns_have_been_retired(
+        PostgresMissingColumn("column repo_scopes.access_key does not exist")
     )
     assert not _legacy_columns_have_been_retired(
         PostgrestMissingColumn("Could not find the 'other_column' column of 'repo_scopes'")


### PR DESCRIPTION
<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
