### PR TITLE
fix(ci): pass protected secrets to reusable workflows

### DIFF
--- a/.github/workflows/data-migration.yml
+++ b/.github/workflows/data-migration.yml
@@ -51,6 +51,7 @@ jobs:
     if: inputs.environment == 'staging'
     needs: validate_protected_ref
     uses: ./.github/workflows/_data-migration.yml
+    secrets: inherit
     with:
       environment: staging
       migration_id: ${{ inputs.migration_id }}
@@ -60,6 +61,7 @@ jobs:
     if: inputs.environment == 'production' && inputs.operation == 'run'
     needs: validate_protected_ref
     uses: ./.github/workflows/_data-migration.yml
+    secrets: inherit
     with:
       environment: staging
       migration_id: ${{ inputs.migration_id }}
@@ -75,6 +77,7 @@ jobs:
       - validate_protected_ref
       - production_staging_evidence
     uses: ./.github/workflows/_data-migration.yml
+    secrets: inherit
     with:
       environment: production
       migration_id: ${{ inputs.migration_id }}

--- a/.github/workflows/migrate-production.yml
+++ b/.github/workflows/migrate-production.yml
@@ -17,5 +17,6 @@ permissions:
 jobs:
   deploy:
     uses: ./.github/workflows/_schema-deploy.yml
+    secrets: inherit
     with:
       environment: production

--- a/.github/workflows/migrate-staging.yml
+++ b/.github/workflows/migrate-staging.yml
@@ -12,5 +12,6 @@ permissions:
 jobs:
   deploy:
     uses: ./.github/workflows/_schema-deploy.yml
+    secrets: inherit
     with:
       environment: staging

--- a/backend/tests/infra/data_migrations/test_workflows.py
+++ b/backend/tests/infra/data_migrations/test_workflows.py
@@ -81,7 +81,19 @@ def test_production_data_work_cannot_run_from_untrusted_ref() -> None:
     assert "environment: staging" in dispatcher
     assert "operation: verify" in dispatcher
     assert "needs.production_staging_evidence.result == 'success'" in dispatcher
-    assert "secrets:" not in dispatcher
+
+
+def test_reusable_database_workflows_receive_protected_secrets() -> None:
+    staging = (WORKFLOWS / "migrate-staging.yml").read_text()
+    production = (WORKFLOWS / "migrate-production.yml").read_text()
+    dispatcher = (WORKFLOWS / "data-migration.yml").read_text()
+
+    # GitHub does not pass secrets to reusable workflows automatically. Every
+    # direct caller must cross that boundary explicitly; the called job then
+    # selects the protected staging/production Environment.
+    assert staging.count("secrets: inherit") == 1
+    assert production.count("secrets: inherit") == 1
+    assert dispatcher.count("secrets: inherit") == 3
 
 
 def test_needs_expressions_use_identifier_safe_job_ids() -> None:


### PR DESCRIPTION
## Summary

- pass protected GitHub Environment secrets across every reusable database-workflow boundary
- cover staging schema, production schema, staging data migration, staging evidence, and production data migration callers
- replace the incorrect regression assertion with exact caller-count coverage

## Root cause

GitHub does not pass secrets to reusable workflows automatically. The called staging job selected the correct Environment, but all Supabase values were empty because its direct caller omitted `secrets: inherit`.

## Validation

- 85 database migration and authorization tests pass locally
- this PR must pass the existing ephemeral-Supabase upgrade gate before merge

## Scope

This PR targets `qubits`; after merge only the staging schema workflow will be exercised. Production will not be triggered.