### PR TITLE
fix(db): codify object location row security

### DIFF
--- a/backend/tests/infra/data_migrations/test_schema_security.py
+++ b/backend/tests/infra/data_migrations/test_schema_security.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).resolve().parents[4]
+
+
+def test_version_object_locations_is_confined_behind_rls() -> None:
+    migration = (
+        REPOSITORY
+        / "supabase"
+        / "migrations"
+        / "20260713000000_enable_version_object_locations_rls.sql"
+    ).read_text(encoding="utf-8")
+
+    assert "ALTER TABLE public.version_object_locations ENABLE ROW LEVEL SECURITY;" in migration
+    assert "FROM PUBLIC, anon, authenticated;" in migration
+    assert "ON public.version_object_locations TO service_role;" in migration

--- a/supabase/migrations/20260713000000_enable_version_object_locations_rls.sql
+++ b/supabase/migrations/20260713000000_enable_version_object_locations_rls.sql
@@ -1,0 +1,14 @@
+-- Keep packed-object location metadata behind the service-role boundary.
+-- The table lives in the API-exposed public schema and therefore must never
+-- rely on grants alone as its row-access boundary.
+
+BEGIN;
+
+ALTER TABLE public.version_object_locations ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.version_object_locations
+    FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE
+    ON public.version_object_locations TO service_role;
+
+COMMIT;

--- a/supabase/tests/_support/schema_contracts.inc
+++ b/supabase/tests/_support/schema_contracts.inc
@@ -171,7 +171,20 @@ BEGIN
         RAISE EXCEPTION 'SMOKE TEST FAILED: cas_update_root_hash returned NULL (expected boolean)';
     END IF;
 
-    RAISE NOTICE 'SMOKE TEST PASSED: CAS RPCs have correct TEXT signatures and invoke without type errors';
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'version_object_locations'
+          AND c.relkind = 'r'
+          AND c.relrowsecurity
+    ) THEN
+        RAISE EXCEPTION
+            'SMOKE TEST FAILED: version_object_locations must have row-level security enabled';
+    END IF;
+
+    RAISE NOTICE 'SMOKE TEST PASSED: CAS RPCs and object-location RLS are consistent';
 END;
 $$;
 


### PR DESCRIPTION
## Summary

- add an idempotent schema migration enabling RLS on `public.version_object_locations`
- retain service-role CRUD while revoking public, anon, and authenticated access
- make the shared post-deploy smoke assert that the RLS boundary remains enabled
- add a repository regression test for the security migration

## Root cause

The real staging database already had RLS enabled, but migration replay did not. Post-deploy drift correctly reported the missing repository contract.

## Validation

- 87 migration and authorization tests pass locally
- PR gate will rebuild and upgrade an ephemeral Supabase database

## Scope

Target is `qubits`; production is not triggered.