### PR TITLE
feat(ci): add audited staging data release

### DIFF
--- a/.github/workflows/migrate-staging.yml
+++ b/.github/workflows/migrate-staging.yml
@@ -1,4 +1,4 @@
-name: Deploy Schema to Qubits
+name: Deploy Database to Qubits
 
 on:
   push:
@@ -10,8 +10,89 @@ permissions:
   contents: read
 
 jobs:
+  validate_ref:
+    name: Validate protected staging source
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Enforce qubits branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/qubits" ]; then
+            echo "::error::Staging database releases must run from the qubits branch."
+            exit 1
+          fi
+
+  resolve_data_release:
+    name: Resolve staged data release
+    if: github.event_name == 'workflow_dispatch'
+    needs: validate_ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      migration_id: ${{ steps.release.outputs.migration_id }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Validate staged migration pointer
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          request="supabase/releases/staging-data-migration.json"
+          migration_id=$(jq -er '.migration_id | select(type == "string")' "$request")
+          case "$migration_id" in
+            ''|*[!0-9A-Za-z_]*)
+              echo "::error::Invalid staging data migration ID."
+              exit 1
+              ;;
+          esac
+          if [ ! -d "supabase/data_migrations/$migration_id" ]; then
+            echo "::error::Staged data migration artifact does not exist."
+            exit 1
+          fi
+          echo "migration_id=$migration_id" >> "$GITHUB_OUTPUT"
+
   deploy:
+    needs: validate_ref
     uses: ./.github/workflows/_schema-deploy.yml
     secrets: inherit
     with:
       environment: staging
+
+  data_plan:
+    if: github.event_name == 'workflow_dispatch'
+    needs:
+      - deploy
+      - resolve_data_release
+    uses: ./.github/workflows/_data-migration.yml
+    secrets: inherit
+    with:
+      environment: staging
+      migration_id: ${{ needs.resolve_data_release.outputs.migration_id }}
+      operation: plan
+
+  data_run:
+    if: github.event_name == 'workflow_dispatch'
+    needs:
+      - data_plan
+      - resolve_data_release
+    uses: ./.github/workflows/_data-migration.yml
+    secrets: inherit
+    with:
+      environment: staging
+      migration_id: ${{ needs.resolve_data_release.outputs.migration_id }}
+      operation: run
+
+  data_verify:
+    if: github.event_name == 'workflow_dispatch'
+    needs:
+      - data_run
+      - resolve_data_release
+    uses: ./.github/workflows/_data-migration.yml
+    secrets: inherit
+    with:
+      environment: staging
+      migration_id: ${{ needs.resolve_data_release.outputs.migration_id }}
+      operation: verify

--- a/.github/workflows/validate-migrations.yml
+++ b/.github/workflows/validate-migrations.yml
@@ -30,6 +30,7 @@ jobs:
           git diff --quiet "origin/$BASE_REF...HEAD" -- \
             'supabase/migrations/**' \
             'supabase/data_migrations/**' \
+            'supabase/releases/**' \
             'supabase/tests/**' \
             'backend/src/infra/data_migrations/**' \
             'backend/tests/infra/data_migrations/**' \

--- a/backend/tests/infra/data_migrations/test_workflows.py
+++ b/backend/tests/infra/data_migrations/test_workflows.py
@@ -108,17 +108,36 @@ def test_reusable_database_workflows_receive_protected_secrets() -> None:
     # GitHub does not pass secrets to reusable workflows automatically. Every
     # direct caller must cross that boundary explicitly; the called job then
     # selects the protected staging/production Environment.
-    assert staging.count("secrets: inherit") == 1
+    assert staging.count("secrets: inherit") == 4
     assert production.count("secrets: inherit") == 1
     assert dispatcher.count("secrets: inherit") == 3
 
 
+def test_staging_manual_release_is_auditable_and_serial() -> None:
+    staging = (WORKFLOWS / "migrate-staging.yml").read_text()
+    release = (
+        REPOSITORY / "supabase" / "releases" / "staging-data-migration.json"
+    ).read_text()
+
+    assert '"refs/heads/qubits"' in staging
+    assert "github.event_name == 'workflow_dispatch'" in staging
+    assert "supabase/releases/staging-data-migration.json" in staging
+    assert "needs:\n      - deploy\n      - resolve_data_release" in staging
+    assert "needs:\n      - data_plan\n      - resolve_data_release" in staging
+    assert "needs:\n      - data_run\n      - resolve_data_release" in staging
+    assert staging.count("uses: ./.github/workflows/_data-migration.yml") == 3
+    for operation in ("plan", "run", "verify"):
+        assert f"operation: {operation}" in staging
+    assert "20260712_repo_user_permissions_to_project_members" in release
+
+
 def test_needs_expressions_use_identifier_safe_job_ids() -> None:
-    dispatcher = (WORKFLOWS / "data-migration.yml").read_text()
-    for line in dispatcher.splitlines():
-        if "needs." in line:
-            reference = line.split("needs.", 1)[1].split(".", 1)[0]
-            assert "-" not in reference
+    for name in ("data-migration.yml", "migrate-staging.yml"):
+        workflow = (WORKFLOWS / name).read_text()
+        for line in workflow.splitlines():
+            if "needs." in line:
+                reference = line.split("needs.", 1)[1].split(".", 1)[0]
+                assert "-" not in reference
 
 
 def test_pull_request_validation_never_receives_remote_database_secrets() -> None:
@@ -173,6 +192,7 @@ def test_database_workflow_third_party_actions_are_sha_pinned() -> None:
     for name in (
         "_schema-deploy.yml",
         "_data-migration.yml",
+        "migrate-staging.yml",
         "validate-migrations.yml",
         "main-release-gate.yml",
     ):

--- a/supabase/releases/staging-data-migration.json
+++ b/supabase/releases/staging-data-migration.json
@@ -1,0 +1,3 @@
+{
+  "migration_id": "20260712_repo_user_permissions_to_project_members"
+}


### PR DESCRIPTION
## Summary

- extend the existing default-branch-registered staging workflow with an auditable GitOps data-release pointer
- require the exact `qubits` ref for every staging dispatch
- on manual dispatch, run schema verification followed by data migration `plan → run → verify`
- keep ordinary qubits pushes schema-only
- serialize every database phase through the existing staging environment concurrency boundary

## Why

GitHub only permits manual dispatch for workflows registered on the default branch. The generic data dispatcher currently exists on qubits but not main, and production is explicitly out of scope. This staging entrypoint provides a permanent, reviewable path without touching main or production.

## Release

`supabase/releases/staging-data-migration.json` points to `20260712_repo_user_permissions_to_project_members`.

## Validation

- 88 migration and authorization tests pass locally
- PR checks must rebuild and upgrade ephemeral Supabase before merge

## Scope

Target and runtime are both staging/qubits only.