### PR TITLE
fix(db): enforce and repair project creator admin

### DIFF
--- a/.github/workflows/validate-migrations.yml
+++ b/.github/workflows/validate-migrations.yml
@@ -134,6 +134,21 @@ jobs:
             -f supabase/data_migrations/20260712_repo_user_permissions_to_project_members/contract.pending.sql
           supabase test db
 
+      - name: Verify historical Project creator repair, retry, and receipt
+        env:
+          DATA_MIGRATION_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          supabase db reset --no-seed
+          psql "$DATABASE_URL" -X -v ON_ERROR_STOP=1 \
+            -f supabase/data_migrations/20260713_reconcile_project_creator_admin/test_fixture.sql
+          cd backend
+          uv run puppyone-db run 20260713_reconcile_project_creator_admin
+          uv run puppyone-db run 20260713_reconcile_project_creator_admin
+          cd ..
+          psql "$DATABASE_URL" -X -v ON_ERROR_STOP=1 \
+            -f supabase/data_migrations/20260713_reconcile_project_creator_admin/test_assert.sql
+
       - name: Verify legacy-data upgrade, retry, receipt, and contract path
         env:
           DATA_MIGRATION_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres

--- a/backend/tests/infra/data_migrations/test_workflows.py
+++ b/backend/tests/infra/data_migrations/test_workflows.py
@@ -52,7 +52,7 @@ def test_psql_receives_connection_uri_explicitly() -> None:
     assert "PGDATABASE:" not in schema
     assert "PGDATABASE:" not in validation
     assert 'psql "$DATABASE_URL"' in schema
-    assert validation.count('psql "$DATABASE_URL"') == 4
+    assert validation.count('psql "$DATABASE_URL"') == 6
 
 
 def test_hosted_schema_smoke_has_no_pgtap_runtime_dependency() -> None:
@@ -74,20 +74,26 @@ def test_hosted_schema_smoke_has_no_pgtap_runtime_dependency() -> None:
 
 def test_ordered_data_migration_fixtures_are_not_auto_discovered_by_supabase() -> None:
     supabase_tests = REPOSITORY / "supabase" / "tests"
-    migration = (
+    permission_migration = (
         REPOSITORY
         / "supabase"
         / "data_migrations"
         / "20260712_repo_user_permissions_to_project_members"
     )
+    creator_migration = (
+        REPOSITORY
+        / "supabase"
+        / "data_migrations"
+        / "20260713_reconcile_project_creator_admin"
+    )
     validation = (WORKFLOWS / "validate-migrations.yml").read_text()
 
     assert not list(supabase_tests.glob("*fixture*.sql"))
     assert not list(supabase_tests.glob("*assert*.sql"))
-    assert (migration / "test_fixture.sql").is_file()
-    assert (migration / "test_assert.sql").is_file()
-    assert "test_fixture.sql" in validation
-    assert "test_assert.sql" in validation
+    for migration in (permission_migration, creator_migration):
+        assert (migration / "test_fixture.sql").is_file()
+        assert (migration / "test_assert.sql").is_file()
+        assert migration.name in validation
 
 
 def test_production_data_work_cannot_run_from_untrusted_ref() -> None:
@@ -128,7 +134,7 @@ def test_staging_manual_release_is_auditable_and_serial() -> None:
     assert staging.count("uses: ./.github/workflows/_data-migration.yml") == 3
     for operation in ("plan", "run", "verify"):
         assert f"operation: {operation}" in staging
-    assert "20260712_repo_user_permissions_to_project_members" in release
+    assert "20260713_reconcile_project_creator_admin" in release
 
 
 def test_needs_expressions_use_identifier_safe_job_ids() -> None:

--- a/backend/tests/security/test_unified_authorization_architecture.py
+++ b/backend/tests/security/test_unified_authorization_architecture.py
@@ -155,6 +155,12 @@ def test_migrations_define_nine_table_target_and_staged_retirement():
         / "migrations"
         / "20260712010000_expand_unified_project_authorization.sql"
     ).read_text()
+    creator_guard = (
+        BACKEND.parent
+        / "supabase"
+        / "migrations"
+        / "20260713010000_enforce_project_creator_admin.sql"
+    ).read_text()
     retirement = (
         BACKEND.parent
         / "supabase"
@@ -181,6 +187,10 @@ def test_migrations_define_nine_table_target_and_staged_retirement():
     assert "AND kind = 'cli'" in foundation
     assert "REVOKE ALL ON FUNCTION public.rotate_access_surface_bearer_token" in foundation
     assert "REVOKE ALL ON FUNCTION public.unified_authorization_preflight()" in foundation
+    assert "project_creator_authorization_preflight" in creator_guard
+    assert "trg_project_members_creator_admin_guard" in creator_guard
+    assert "trg_projects_creator_admin_guard" in creator_guard
+    assert "DEFERRABLE INITIALLY DEFERRED" in creator_guard
     assert "REVOKE ALL ON FUNCTION public.unified_authorization_preflight()" in retirement
     assert "requires-data-migration: 20260712_repo_user_permissions" in retirement
     artifact_checksum = DataMigrationCatalog(BACKEND.parent).get(
@@ -201,6 +211,7 @@ def test_migration_functions_pin_a_hardened_search_path():
     migrations = BACKEND.parent / "supabase" / "migrations"
     for name in (
         "20260712010000_expand_unified_project_authorization.sql",
+        "20260713010000_enforce_project_creator_admin.sql",
     ):
         text = (migrations / name).read_text()
         assert "SET search_path = public" not in text
@@ -221,7 +232,7 @@ def test_database_contract_suite_and_ci_gate_are_wired():
     workflow = (
         BACKEND.parent / ".github" / "workflows" / "validate-migrations.yml"
     ).read_text()
-    assert "SELECT plan(55);" in contract
+    assert "SELECT plan(58);" in contract
     assert "has_function_privilege" in contract
     assert contract.count("SELECT throws_ok(") >= 6
     assert "root/non-root identity drift" in contract

--- a/supabase/data_migrations/20260713_reconcile_project_creator_admin/manifest.yml
+++ b/supabase/data_migrations/20260713_reconcile_project_creator_admin/manifest.yml
@@ -1,0 +1,11 @@
+api_version: 1
+id: 20260713_reconcile_project_creator_admin
+description: Restore tenant membership and explicit Project Admin grants for historical Project creators
+kind: sql
+entrypoint: run.sql
+verify: verify.sql
+requires_schema:
+  - "20260713010000"
+required_env: []
+timeout_seconds: 1800
+legacy: false

--- a/supabase/data_migrations/20260713_reconcile_project_creator_admin/run.sql
+++ b/supabase/data_migrations/20260713_reconcile_project_creator_admin/run.sql
@@ -1,0 +1,89 @@
+DO $$
+DECLARE
+    missing_profile_count bigint;
+BEGIN
+    SELECT count(*) INTO missing_profile_count
+    FROM public.projects p
+    LEFT JOIN public.profiles pr ON pr.user_id = p.created_by
+    WHERE p.created_by IS NOT NULL AND pr.user_id IS NULL;
+
+    IF missing_profile_count > 0 THEN
+        RAISE EXCEPTION
+          'Project creator reconciliation blocked: % creator profile(s) are missing',
+          missing_profile_count;
+    END IF;
+END;
+$$;
+
+-- Organization membership is the tenant boundary.  Historical creators that
+-- predate atomic Project creation receive the least-privileged organization
+-- baseline; their Project authority remains explicit and independent below.
+WITH candidates AS (
+    SELECT DISTINCT p.org_id, p.created_by AS user_id
+    FROM public.projects p
+    LEFT JOIN public.org_members om
+      ON om.org_id = p.org_id AND om.user_id = p.created_by
+    WHERE p.created_by IS NOT NULL AND om.id IS NULL
+), inserted AS (
+    INSERT INTO public.org_members (id, org_id, user_id, role)
+    SELECT gen_random_uuid()::text, org_id, user_id, 'viewer'
+    FROM candidates
+    ON CONFLICT (org_id, user_id) DO NOTHING
+    RETURNING org_id, user_id, role
+)
+INSERT INTO public.audit_logs (
+    action, path, project_id, operator_type, operator_id, status, metadata
+)
+SELECT
+    'project_creator.org_membership.reconcile',
+    '',
+    NULL,
+    'system',
+    '20260713_reconcile_project_creator_admin',
+    'success',
+    jsonb_build_object(
+        'org_id', org_id,
+        'user_id', user_id,
+        'role', role
+    )
+FROM inserted;
+
+-- The creator fact is authoritative: a missing or downgraded explicit Project
+-- membership is restored to Admin.  The trigger installed by the guard
+-- schema rejects every future downgrade or deletion of this row.
+WITH reconciled AS (
+    INSERT INTO public.project_members (
+        id, org_id, project_id, user_id, role, granted_by
+    )
+    SELECT
+        gen_random_uuid()::text,
+        p.org_id,
+        p.id,
+        p.created_by,
+        'admin',
+        p.created_by
+    FROM public.projects p
+    WHERE p.created_by IS NOT NULL
+    ON CONFLICT (project_id, user_id) DO UPDATE
+      SET org_id = EXCLUDED.org_id,
+          role = EXCLUDED.role,
+          granted_by = COALESCE(
+              public.project_members.granted_by,
+              EXCLUDED.granted_by
+          )
+      WHERE public.project_members.org_id IS DISTINCT FROM EXCLUDED.org_id
+         OR public.project_members.role IS DISTINCT FROM EXCLUDED.role
+    RETURNING project_id, user_id, role
+)
+INSERT INTO public.audit_logs (
+    action, path, project_id, operator_type, operator_id, status, metadata
+)
+SELECT
+    'project_creator.project_membership.reconcile',
+    '',
+    project_id,
+    'system',
+    '20260713_reconcile_project_creator_admin',
+    'success',
+    jsonb_build_object('user_id', user_id, 'role', role)
+FROM reconciled;

--- a/supabase/data_migrations/20260713_reconcile_project_creator_admin/test_assert.sql
+++ b/supabase/data_migrations/20260713_reconcile_project_creator_admin/test_assert.sql
@@ -1,0 +1,46 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM public.org_members
+        WHERE org_id = 'creator-repair-org'
+          AND user_id = '00000000-0000-0000-0000-000000013102'::uuid
+          AND role = 'viewer'
+    ) THEN
+        RAISE EXCEPTION 'missing creator did not receive the organization Viewer baseline';
+    END IF;
+
+    IF (
+        SELECT count(*)
+        FROM public.project_members
+        WHERE project_id IN (
+            'creator-repair-missing-project',
+            'creator-repair-viewer-project'
+        )
+          AND role = 'admin'
+    ) <> 2 THEN
+        RAISE EXCEPTION 'historical Project creators were not reconciled to explicit Admin';
+    END IF;
+
+    IF (
+        SELECT count(*)
+        FROM public.audit_logs
+        WHERE operator_id = '20260713_reconcile_project_creator_admin'
+          AND action IN (
+              'project_creator.org_membership.reconcile',
+              'project_creator.project_membership.reconcile'
+          )
+    ) <> 3 THEN
+        RAISE EXCEPTION 'creator reconciliation audit facts are incomplete or duplicated';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM public.migration_log
+        WHERE name = '20260713_reconcile_project_creator_admin'
+          AND COALESCE((summary->>'verified')::boolean, false)
+    ) THEN
+        RAISE EXCEPTION 'verified creator reconciliation receipt is missing';
+    END IF;
+END;
+$$;

--- a/supabase/data_migrations/20260713_reconcile_project_creator_admin/test_fixture.sql
+++ b/supabase/data_migrations/20260713_reconcile_project_creator_admin/test_fixture.sql
@@ -1,0 +1,73 @@
+BEGIN;
+
+INSERT INTO auth.users (
+    instance_id, id, aud, role, email, encrypted_password,
+    email_confirmed_at, raw_app_meta_data, raw_user_meta_data,
+    created_at, updated_at
+)
+SELECT
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    fixture.id,
+    'authenticated',
+    'authenticated',
+    fixture.email,
+    '',
+    now(),
+    '{}'::jsonb,
+    '{}'::jsonb,
+    now(),
+    now()
+FROM (VALUES
+    ('00000000-0000-0000-0000-000000013101'::uuid, 'creator-repair-owner@example.test'),
+    ('00000000-0000-0000-0000-000000013102'::uuid, 'creator-repair-missing@example.test'),
+    ('00000000-0000-0000-0000-000000013103'::uuid, 'creator-repair-viewer@example.test')
+) AS fixture(id, email);
+
+INSERT INTO public.organizations (
+    id, name, slug, type, plan, seat_limit, created_by
+) VALUES (
+    'creator-repair-org', 'Creator Repair Test', 'creator-repair-test',
+    'team', 'enterprise', 10,
+    '00000000-0000-0000-0000-000000013101'::uuid
+);
+
+INSERT INTO public.org_members (id, org_id, user_id, role)
+VALUES
+    ('creator-repair-owner-membership', 'creator-repair-org',
+     '00000000-0000-0000-0000-000000013101'::uuid, 'owner'),
+    ('creator-repair-viewer-membership', 'creator-repair-org',
+     '00000000-0000-0000-0000-000000013103'::uuid, 'viewer');
+
+-- Recreate facts written before the creator guards existed.  Only this local
+-- fixture disables them; the migration under test runs with all guards active.
+ALTER TABLE public.projects
+    DISABLE TRIGGER trg_projects_creator_admin_guard;
+ALTER TABLE public.project_members
+    DISABLE TRIGGER trg_project_members_creator_admin_guard;
+
+INSERT INTO public.projects (id, name, org_id, created_by)
+VALUES
+    ('creator-repair-missing-project', 'Missing Membership',
+     'creator-repair-org',
+     '00000000-0000-0000-0000-000000013102'::uuid),
+    ('creator-repair-viewer-project', 'Downgraded Creator',
+     'creator-repair-org',
+     '00000000-0000-0000-0000-000000013103'::uuid);
+
+INSERT INTO public.project_members (
+    id, org_id, project_id, user_id, role, granted_by
+) VALUES (
+    'creator-repair-viewer-project-membership',
+    'creator-repair-org',
+    'creator-repair-viewer-project',
+    '00000000-0000-0000-0000-000000013103'::uuid,
+    'viewer',
+    '00000000-0000-0000-0000-000000013101'::uuid
+);
+
+ALTER TABLE public.project_members
+    ENABLE TRIGGER trg_project_members_creator_admin_guard;
+ALTER TABLE public.projects
+    ENABLE TRIGGER trg_projects_creator_admin_guard;
+
+COMMIT;

--- a/supabase/data_migrations/20260713_reconcile_project_creator_admin/verify.sql
+++ b/supabase/data_migrations/20260713_reconcile_project_creator_admin/verify.sql
@@ -1,0 +1,22 @@
+DO $$
+DECLARE
+    report jsonb;
+BEGIN
+    report := public.project_creator_authorization_preflight();
+
+    IF (report->>'creator_missing_profile')::bigint > 0
+       OR (report->>'creator_missing_org_membership')::bigint > 0
+       OR (report->>'creator_missing_project_membership')::bigint > 0
+       OR (report->>'creator_non_admin_project_membership')::bigint > 0 THEN
+        RAISE EXCEPTION
+          'Project creator reconciliation verification failed; preflight=%',
+          report;
+    END IF;
+
+    IF (public.unified_authorization_preflight()
+          ->>'creator_admin_unresolved')::bigint > 0 THEN
+        RAISE EXCEPTION
+          'Project creator reconciliation verification failed: unresolved creator Admin facts remain';
+    END IF;
+END;
+$$;

--- a/supabase/migrations/20260713010000_enforce_project_creator_admin.sql
+++ b/supabase/migrations/20260713010000_enforce_project_creator_admin.sql
@@ -1,0 +1,171 @@
+-- ===========================================================================
+-- Keep Project creator authority internally consistent
+-- ===========================================================================
+-- A Project creator is a tenant member and an explicit Project Admin.  The
+-- atomic creation RPC has published both facts since 20260712010000, but
+-- direct membership mutation could still remove or downgrade the creator.
+-- This forward migration closes that write path and exposes disjoint,
+-- aggregate-only diagnostics for historical reconciliation.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '15min';
+
+CREATE OR REPLACE FUNCTION public.project_creator_authorization_preflight()
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, public, pg_temp
+AS $$
+SELECT jsonb_build_object(
+    'creator_missing_profile', (
+        SELECT count(*)
+        FROM public.projects p
+        LEFT JOIN public.profiles pr ON pr.user_id = p.created_by
+        WHERE p.created_by IS NOT NULL AND pr.user_id IS NULL
+    ),
+    'creator_missing_org_membership', (
+        SELECT count(*)
+        FROM public.projects p
+        JOIN public.profiles pr ON pr.user_id = p.created_by
+        LEFT JOIN public.org_members om
+          ON om.org_id = p.org_id AND om.user_id = p.created_by
+        WHERE p.created_by IS NOT NULL AND om.id IS NULL
+    ),
+    'creator_missing_project_membership', (
+        SELECT count(*)
+        FROM public.projects p
+        JOIN public.org_members om
+          ON om.org_id = p.org_id AND om.user_id = p.created_by
+        LEFT JOIN public.project_members pm
+          ON pm.project_id = p.id AND pm.user_id = p.created_by
+        WHERE p.created_by IS NOT NULL AND pm.id IS NULL
+    ),
+    'creator_non_admin_project_membership', (
+        SELECT count(*)
+        FROM public.projects p
+        JOIN public.org_members om
+          ON om.org_id = p.org_id AND om.user_id = p.created_by
+        JOIN public.project_members pm
+          ON pm.project_id = p.id AND pm.user_id = p.created_by
+        WHERE p.created_by IS NOT NULL AND pm.role IS DISTINCT FROM 'admin'
+    )
+);
+$$;
+
+REVOKE ALL ON FUNCTION public.project_creator_authorization_preflight()
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.project_creator_authorization_preflight()
+    TO service_role;
+
+-- Reject direct or RPC-driven deletion, reassignment, or downgrade of the
+-- creator's explicit Project Admin row.  A future ownership-transfer RPC can
+-- change projects.created_by and the two membership facts in one transaction.
+CREATE OR REPLACE FUNCTION public._enforce_project_creator_admin_member()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, pg_temp
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        IF EXISTS (
+            SELECT 1
+            FROM public.projects p
+            WHERE p.id = OLD.project_id AND p.created_by = OLD.user_id
+        ) THEN
+            RAISE EXCEPTION 'project creator must retain explicit Project Admin membership'
+                USING ERRCODE = '23514';
+        END IF;
+        RETURN OLD;
+    END IF;
+
+    IF TG_OP = 'UPDATE' AND EXISTS (
+        SELECT 1
+        FROM public.projects p
+        WHERE p.id = OLD.project_id
+          AND p.created_by = OLD.user_id
+          AND (
+              NEW.project_id IS DISTINCT FROM OLD.project_id
+              OR NEW.user_id IS DISTINCT FROM OLD.user_id
+              OR NEW.org_id IS DISTINCT FROM OLD.org_id
+              OR NEW.role IS DISTINCT FROM 'admin'
+          )
+    ) THEN
+        RAISE EXCEPTION 'project creator must retain explicit Project Admin membership'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF TG_OP IN ('INSERT', 'UPDATE')
+       AND NEW.role IS DISTINCT FROM 'admin'
+       AND EXISTS (
+           SELECT 1
+           FROM public.projects p
+           WHERE p.id = NEW.project_id AND p.created_by = NEW.user_id
+       ) THEN
+        RAISE EXCEPTION 'project creator must retain explicit Project Admin membership'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._enforce_project_creator_admin_member()
+    FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS trg_project_members_creator_admin_guard
+    ON public.project_members;
+CREATE TRIGGER trg_project_members_creator_admin_guard
+    BEFORE INSERT OR UPDATE OR DELETE ON public.project_members
+    FOR EACH ROW EXECUTE FUNCTION public._enforce_project_creator_admin_member();
+
+-- Projects may be inserted before their creator membership within the same
+-- transaction, so validate this side of the cross-table invariant at commit.
+CREATE OR REPLACE FUNCTION public._assert_project_creator_admin_at_commit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, pg_temp
+AS $$
+DECLARE
+    project_ids text[];
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        project_ids := ARRAY[NEW.id];
+    ELSE
+        project_ids := ARRAY[OLD.id, NEW.id];
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM public.projects p
+        LEFT JOIN public.org_members om
+          ON om.org_id = p.org_id AND om.user_id = p.created_by
+        LEFT JOIN public.project_members pm
+          ON pm.project_id = p.id
+         AND pm.org_id = p.org_id
+         AND pm.user_id = p.created_by
+        WHERE p.id = ANY(project_ids)
+          AND p.created_by IS NOT NULL
+          AND (om.id IS NULL OR pm.role IS DISTINCT FROM 'admin')
+    ) THEN
+        RAISE EXCEPTION 'project creator must be an organization member and explicit Project Admin'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._assert_project_creator_admin_at_commit()
+    FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS trg_projects_creator_admin_guard ON public.projects;
+CREATE CONSTRAINT TRIGGER trg_projects_creator_admin_guard
+    AFTER INSERT OR UPDATE OF id, org_id, created_by ON public.projects
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION public._assert_project_creator_admin_at_commit();
+
+COMMIT;

--- a/supabase/releases/staging-data-migration.json
+++ b/supabase/releases/staging-data-migration.json
@@ -1,3 +1,3 @@
 {
-  "migration_id": "20260712_repo_user_permissions_to_project_members"
+  "migration_id": "20260713_reconcile_project_creator_admin"
 }

--- a/supabase/tests/_support/schema_contracts.inc
+++ b/supabase/tests/_support/schema_contracts.inc
@@ -69,6 +69,58 @@ BEGIN
 END;
 $$;
 
+DO $$
+BEGIN
+    IF to_regprocedure('public.project_creator_authorization_preflight()') IS NULL THEN
+        RAISE EXCEPTION
+            'SMOKE TEST FAILED: Project creator authorization preflight is missing';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_trigger t
+        JOIN pg_class c ON c.oid = t.tgrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'project_members'
+          AND t.tgname = 'trg_project_members_creator_admin_guard'
+          AND NOT t.tgisinternal
+          AND t.tgenabled <> 'D'
+    ) THEN
+        RAISE EXCEPTION
+            'SMOKE TEST FAILED: Project creator membership guard is missing or disabled';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_trigger t
+        JOIN pg_class c ON c.oid = t.tgrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'projects'
+          AND t.tgname = 'trg_projects_creator_admin_guard'
+          AND t.tgdeferrable
+          AND t.tginitdeferred
+          AND t.tgenabled <> 'D'
+    ) THEN
+        RAISE EXCEPTION
+            'SMOKE TEST FAILED: deferred Project creator fact guard is missing or disabled';
+    END IF;
+
+    IF has_function_privilege(
+        'anon', 'public.project_creator_authorization_preflight()', 'EXECUTE'
+    ) OR has_function_privilege(
+        'authenticated', 'public.project_creator_authorization_preflight()', 'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION
+            'SMOKE TEST FAILED: creator diagnostics are exposed to client roles';
+    END IF;
+
+    RAISE NOTICE
+        'SMOKE TEST PASSED: Project creator authorization guards are installed';
+END;
+$$;
+
 -- ============================================================================
 -- Check 2: MUT CAS RPCs must use p_project_id TEXT (not UUID).
 --

--- a/supabase/tests/unified_project_authorization_test.sql
+++ b/supabase/tests/unified_project_authorization_test.sql
@@ -6,7 +6,7 @@
 
 BEGIN;
 
-SELECT plan(55);
+SELECT plan(58);
 
 DO $$
 DECLARE
@@ -186,6 +186,36 @@ SELECT is(
        AND user_id = '00000000-0000-0000-0000-000000029101'),
     'admin',
     'Project creation publishes creator Admin membership atomically'
+);
+
+SELECT throws_ok(
+    $$SELECT * FROM public.update_project_member_role_authorized(
+        'issue029-private',
+        '00000000-0000-0000-0000-000000029101'::uuid,
+        'viewer',
+        '00000000-0000-0000-0000-000000029101'::uuid
+    )$$,
+    '23514',
+    'project creator must retain explicit Project Admin membership',
+    'Project creator cannot be downgraded through the authorized RPC'
+);
+SELECT throws_ok(
+    $$SELECT public.remove_project_member_authorized(
+        'issue029-private',
+        '00000000-0000-0000-0000-000000029101'::uuid,
+        '00000000-0000-0000-0000-000000029101'::uuid
+    )$$,
+    '23514',
+    'project creator must retain explicit Project Admin membership',
+    'Project creator cannot be removed through the authorized RPC'
+);
+SELECT throws_ok(
+    $$DELETE FROM public.org_members
+      WHERE org_id = 'issue029-org'
+        AND user_id = '00000000-0000-0000-0000-000000029101'::uuid$$,
+    '23514',
+    'project creator must retain explicit Project Admin membership',
+    'tenant membership cannot be removed before Project ownership is transferred'
 );
 
 SELECT throws_ok(


### PR DESCRIPTION
## Outcome
- enforce the Project creator tenant-member + explicit Admin invariant at the database boundary
- add aggregate-only creator diagnostics without logging tenant identifiers
- add an immutable SQL data repair with audit facts, verification, and receipt
- stage that repair through the qubits/staging release pointer

## Safety
- production/main is not targeted
- schema deployment remains additive
- data repair runs transactionally under the existing advisory lock and protected staging Environment
- missing creator profiles fail closed before any write

## Validation
- data migration catalog lint
- immutable database policy
- 80 architecture/workflow regression tests
- CI runs fresh install, historical fixture, retry/idempotency, pgTAP, schema drift, and hosted staging smoke