### PR TITLE
chore(db): stage legacy project permission migration

### DIFF
--- a/backend/tests/infra/data_migrations/test_workflows.py
+++ b/backend/tests/infra/data_migrations/test_workflows.py
@@ -134,7 +134,7 @@ def test_staging_manual_release_is_auditable_and_serial() -> None:
     assert staging.count("uses: ./.github/workflows/_data-migration.yml") == 3
     for operation in ("plan", "run", "verify"):
         assert f"operation: {operation}" in staging
-    assert "20260713_reconcile_project_creator_admin" in release
+    assert "20260712_repo_user_permissions_to_project_members" in release
 
 
 def test_needs_expressions_use_identifier_safe_job_ids() -> None:

--- a/supabase/releases/staging-data-migration.json
+++ b/supabase/releases/staging-data-migration.json
@@ -1,3 +1,3 @@
 {
-  "migration_id": "20260713_reconcile_project_creator_admin"
+  "migration_id": "20260712_repo_user_permissions_to_project_members"
 }


### PR DESCRIPTION
## Outcome
Advance the auditable staging release pointer to the original immutable data migration now that the Project creator invariant repair has a verified staging receipt.

## Scope
- release pointer only
- target is qubits/staging
- no production/main dispatch

## Required execution after merge
Run the protected staging workflow in order: schema attestation, plan, transactional run, independent verify.