### PR TITLE
fix(db): repair Projects missing their root Scope

### DIFF
--- a/scripts/test-repository-target-migration.sh
+++ b/scripts/test-repository-target-migration.sh
@@ -201,6 +201,17 @@ fi
         -c "DO \$\$ BEGIN IF to_regclass('public.repo_scopes') IS NULL THEN RAISE EXCEPTION 'failed preflight mutated the schema'; END IF; IF EXISTS (SELECT 1 FROM public.migration_log WHERE name = '20260715_project_owned_repository_targets_preflight') THEN RAISE EXCEPTION 'failed preflight wrote a receipt'; END IF; END \$\$"
 )
 
+# The released repair restores the missing root, never touches healthy
+# Projects, is idempotent, and unblocks the previously rejected preflight.
+run_data_migration 20260717_repair_missing_root_scopes
+run_data_migration 20260717_repair_missing_root_scopes
+(
+    cd "$repository_root"
+    psql "$database_url" -X -v ON_ERROR_STOP=1 \
+        -f supabase/test_fixtures/root_scope_repair_assert.sql
+)
+run_data_migration 20260715_project_owned_repository_targets_preflight
+
 restore_contract
 restore_removal
 restore_initialization

--- a/supabase/data_migrations/20260717_repair_missing_root_scopes/README.md
+++ b/supabase/data_migrations/20260717_repair_missing_root_scopes/README.md
@@ -1,0 +1,20 @@
+# Repair missing Project root Scopes
+
+Staging holds historical Projects whose creation committed the Project row
+without its single root Scope (`repo_scopes` row with `path = ''`,
+`is_root = true`). Every such Project fails the fail-closed readiness audit in
+`20260715_project_owned_repository_targets_preflight`, which blocks the
+Project-owned repository target cutover and therefore every schema deployment
+behind it.
+
+`run.sql` restores exactly the row the application would have created
+(`Root`, `path=''`, `exclude='[]'`, `mode='rw'`, `is_root=true`) for Projects
+with no root Scope, and records one audit fact per repaired Project. It fails
+closed without mutating anything when a non-root Scope already claims the
+root path. `verify.sql` fails closed while any Project lacks exactly one root
+Scope and reports the missing/surplus split, so a `plan`/`run` dispatch also
+serves as the sanctioned diagnosis of the protected environment.
+
+Release order: run this repair, then run the
+`20260715_project_owned_repository_targets_preflight` data migration, then
+deploy schema.

--- a/supabase/data_migrations/20260717_repair_missing_root_scopes/manifest.yml
+++ b/supabase/data_migrations/20260717_repair_missing_root_scopes/manifest.yml
@@ -1,0 +1,11 @@
+api_version: 1
+id: 20260717_repair_missing_root_scopes
+description: Restore the single legacy root Scope for historical Projects created without one
+kind: sql
+entrypoint: run.sql
+verify: verify.sql
+requires_schema:
+  - "20260713020000"
+required_env: []
+timeout_seconds: 900
+legacy: false

--- a/supabase/data_migrations/20260717_repair_missing_root_scopes/run.sql
+++ b/supabase/data_migrations/20260717_repair_missing_root_scopes/run.sql
@@ -1,0 +1,51 @@
+-- Historical Project creation could commit the Project row without its root
+-- Scope. Every such Project blocks the repository target preflight
+-- (20260715_project_owned_repository_targets_preflight) and is unusable by
+-- the application, which assumes one root Scope per Project.
+--
+-- This repair restores exactly the row the application would have created:
+-- path='', exclude='[]', mode='rw', is_root=true. It never touches Projects
+-- that already have a root Scope, and it records one audit fact per repaired
+-- Project.
+
+DO $$
+DECLARE
+    blocked bigint;
+BEGIN
+    -- A non-root Scope on the root path is ambiguous corruption this repair
+    -- must not guess about; the (project_id, path) UNIQUE would silently
+    -- swallow the repair row. Fail closed before mutating anything.
+    SELECT count(*) INTO blocked
+    FROM public.repo_scopes
+    WHERE NOT is_root AND path = '';
+    IF blocked > 0 THEN
+        RAISE EXCEPTION
+          'root Scope repair blocked: % non-root Scope rows already claim the root path',
+          blocked;
+    END IF;
+END;
+$$;
+
+WITH repaired AS (
+    INSERT INTO public.repo_scopes (project_id, name, path, exclude, mode, is_root)
+    SELECT p.id, 'Root', '', '[]'::jsonb, 'rw', true
+    FROM public.projects p
+    WHERE NOT EXISTS (
+        SELECT 1 FROM public.repo_scopes s
+        WHERE s.project_id = p.id AND s.is_root = true
+    )
+    ORDER BY p.id
+    RETURNING id, project_id
+)
+INSERT INTO public.audit_logs (
+    action, path, project_id, operator_type, operator_id, status, metadata
+)
+SELECT
+    'repository_target.root_scope.repair',
+    '',
+    project_id,
+    'system',
+    '20260717_repair_missing_root_scopes',
+    'success',
+    jsonb_build_object('scope_id', id)
+FROM repaired;

--- a/supabase/data_migrations/20260717_repair_missing_root_scopes/verify.sql
+++ b/supabase/data_migrations/20260717_repair_missing_root_scopes/verify.sql
@@ -1,0 +1,28 @@
+DO $$
+DECLARE
+    zero_roots bigint;
+    surplus_roots bigint;
+BEGIN
+    SELECT count(*) INTO zero_roots
+    FROM public.projects p
+    WHERE NOT EXISTS (
+        SELECT 1 FROM public.repo_scopes s
+        WHERE s.project_id = p.id AND s.is_root = true
+    );
+
+    SELECT count(*) INTO surplus_roots
+    FROM (
+        SELECT s.project_id
+        FROM public.repo_scopes s
+        WHERE s.is_root = true
+        GROUP BY s.project_id
+        HAVING count(*) > 1
+    ) surplus;
+
+    IF zero_roots > 0 OR surplus_roots > 0 THEN
+        RAISE EXCEPTION
+          'root Scope repair verification failed: % Projects without a root Scope, % Projects with surplus root Scopes',
+          zero_roots, surplus_roots;
+    END IF;
+END;
+$$;

--- a/supabase/test_fixtures/repository_target_corrupt_missing_root.sql
+++ b/supabase/test_fixtures/repository_target_corrupt_missing_root.sql
@@ -34,4 +34,22 @@ SELECT * FROM public.create_project_with_admin(
     'issue039-corrupt-share-token'
 );
 
+-- A healthy neighbor proves the root Scope repair never touches Projects
+-- that already own their single root.
+SELECT * FROM public.create_project_with_admin(
+    'issue039-healthy-root-project',
+    'Healthy Root Project',
+    NULL,
+    'issue039-corrupt-org',
+    '00000000-0000-0000-0000-000000039099'::uuid,
+    'issue039-healthy-share-token'
+);
+
+INSERT INTO public.repo_scopes (
+    id, project_id, name, path, exclude, mode, is_root
+) VALUES (
+    'issue039-healthy-root-scope', 'issue039-healthy-root-project',
+    'Root', '', '[]', 'rw', true
+);
+
 COMMIT;

--- a/supabase/test_fixtures/root_scope_repair_assert.sql
+++ b/supabase/test_fixtures/root_scope_repair_assert.sql
@@ -1,0 +1,56 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM public.repo_scopes
+        WHERE project_id = 'issue039-missing-root-project'
+          AND is_root = true
+          AND path = ''
+          AND exclude = '[]'::jsonb
+          AND mode = 'rw'
+    ) THEN
+        RAISE EXCEPTION 'missing root Scope was not restored in canonical shape';
+    END IF;
+
+    IF (
+        SELECT count(*)
+        FROM public.repo_scopes
+        WHERE project_id = 'issue039-healthy-root-project' AND is_root = true
+    ) <> 1 OR NOT EXISTS (
+        SELECT 1
+        FROM public.repo_scopes
+        WHERE id = 'issue039-healthy-root-scope' AND is_root = true
+    ) THEN
+        RAISE EXCEPTION 'repair mutated a healthy Project root Scope';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM public.projects p
+        LEFT JOIN public.repo_scopes s
+          ON s.project_id = p.id AND s.is_root = true
+        GROUP BY p.id
+        HAVING count(s.id) <> 1
+    ) THEN
+        RAISE EXCEPTION 'a Project still lacks exactly one root Scope after repair';
+    END IF;
+
+    IF (
+        SELECT count(*)
+        FROM public.audit_logs
+        WHERE operator_id = '20260717_repair_missing_root_scopes'
+          AND action = 'repository_target.root_scope.repair'
+    ) <> 1 THEN
+        RAISE EXCEPTION 'root Scope repair audit facts are incomplete or duplicated';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM public.migration_log
+        WHERE name = '20260717_repair_missing_root_scopes'
+          AND COALESCE((summary->>'verified')::boolean, false)
+    ) THEN
+        RAISE EXCEPTION 'verified root Scope repair receipt is missing';
+    END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- Staging holds Projects whose creation committed the Project row without its single root Scope, so the fail-closed readiness audit in `20260715_project_owned_repository_targets_preflight` blocks every staging schema deployment (`repository target preflight blocked: 2 Projects lack exactly one legacy root`).
- Adds the immutable data migration `20260717_repair_missing_root_scopes`: restores the exact canonical root row (`path=''`, `exclude='[]'`, `mode='rw'`, `is_root=true`) for Projects with no root Scope, records one audit fact per repair, and fails closed without mutating anything when a non-root Scope already claims the root path. `verify.sql` reports the missing/surplus split, so a protected dispatch doubles as the sanctioned diagnosis.
- Extends the upgrade harness: corrupt fixture now carries a healthy neighbor Project; the harness proves the repair is idempotent, never touches healthy Projects, and unblocks the previously rejected preflight.

## Release sequence (staging)
1. Merge this PR into `qubits` (push-triggered deploy stays red until step 3 — expected).
2. Dispatch **Data Migration**: environment `staging`, migration `20260717_repair_missing_root_scopes`, operation `run`.
3. Dispatch **Deploy Database to Qubits** (workflow_dispatch): runs the staged `20260715` preflight plan/run/verify, then deploys the pending schema migrations including the contract cutover.

## Test plan
- [x] `uv run puppyone-db lint` (6 artifacts) and `uv run puppyone-db policy --base-ref origin/qubits`
- [x] `uv run pytest tests/infra/data_migrations tests/security/test_credential_backfill_ci_contract.py tests/security/test_unified_authorization_architecture.py` (91 passed)
- [x] SQL parse + `bash -n` on the harness
- [ ] PR CI `validate_local_database` runs the extended harness end-to-end (fresh install + corrupt-fixture repair proof)

Made with [Cursor](https://cursor.com)