### PR TITLE
fix(auth): preserve legacy Redis configuration

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -267,8 +267,11 @@ class Settings(BaseSettings):
     def enforce_auth_security_store_safety(self):
         """Hosted auth controls require one shared, cross-replica Redis."""
         if self.APP_ENV not in {"development", "test"}:
-            if not self.AUTH_SECURITY_REDIS_URL:
-                raise ValueError("AUTH_SECURITY_REDIS_URL is required outside development/test")
+            if not self.auth_security_redis_url:
+                raise ValueError(
+                    "AUTH_SECURITY_REDIS_URL (or legacy RATELIMIT_REDIS_URL / "
+                    "ETL_REDIS_URL) is required outside development/test"
+                )
             if not self.NOTIFICATIONS_REDIS_URL:
                 raise ValueError("NOTIFICATIONS_REDIS_URL is required outside development/test")
             if not self.DESKTOP_AUTH_PUBLIC_BASE_URL.startswith("https://"):
@@ -346,6 +349,11 @@ class Settings(BaseSettings):
     MCP_TOKEN_TTL_SECONDS: int = 30 * 24 * 60 * 60  # 30 days
     # Shared fail-closed store for OAuth one-time state and auth rate limits.
     AUTH_SECURITY_REDIS_URL: str = ""
+    # Compatibility inputs retained for deployments predating the shared auth
+    # security store. They are never fail-open fallbacks: when selected, the
+    # Redis store remains mandatory and every operation still fails closed.
+    RATELIMIT_REDIS_URL: str = ""
+    ETL_REDIS_URL: str = ""
     # Browser/CLI-reachable Supabase origin. Empty means SUPABASE_URL is already public.
     SUPABASE_PUBLIC_URL: str = ""
     # Browser-reachable Puppyone web origin used by the Desktop login handoff.
@@ -358,6 +366,29 @@ class Settings(BaseSettings):
     # commit_update events are fanned out across replicas via Redis pub/sub.
     # Local development may leave this empty; hosted validation requires it.
     NOTIFICATIONS_REDIS_URL: str = ""
+
+    @property
+    def auth_security_redis_url(self) -> str:
+        """Resolve the shared Redis store without breaking older deployments.
+
+        ``AUTH_SECURITY_REDIS_URL`` is the explicit modern setting. Before it
+        existed, hosted installs commonly supplied either the old rate-limit
+        URL or the shared ARQ URL. All three are Redis connection strings; the
+        auth store uses its own key namespace and remains fail-closed.
+        """
+
+        return next(
+            (
+                value.strip()
+                for value in (
+                    self.AUTH_SECURITY_REDIS_URL,
+                    self.RATELIMIT_REDIS_URL,
+                    self.ETL_REDIS_URL,
+                )
+                if value.strip()
+            ),
+            "",
+        )
 
     # Anthropic configuration
     ANTHROPIC_API_KEY: str = ""

--- a/backend/src/platform/auth/shared_security_store.py
+++ b/backend/src/platform/auth/shared_security_store.py
@@ -86,5 +86,4 @@ class RedisSecurityStore:
 
 @lru_cache(maxsize=1)
 def get_auth_security_store() -> RedisSecurityStore:
-    return RedisSecurityStore(settings.AUTH_SECURITY_REDIS_URL)
-
+    return RedisSecurityStore(settings.auth_security_redis_url)

--- a/backend/tests/core/test_config_allowed_hosts.py
+++ b/backend/tests/core/test_config_allowed_hosts.py
@@ -72,3 +72,36 @@ def test_allowed_hosts_default_for_development_without_debug() -> None:
         "http://localhost:5177",
         "http://127.0.0.1:5177",
     ]
+
+
+def test_auth_security_redis_url_prefers_dedicated_setting() -> None:
+    settings = Settings(
+        _env_file=None,
+        APP_ENV="test",
+        AUTH_SECURITY_REDIS_URL="redis://dedicated.invalid:6379/0",
+        RATELIMIT_REDIS_URL="redis://legacy-rate-limit.invalid:6379/0",
+        ETL_REDIS_URL="redis://legacy-etl.invalid:6379/0",
+    )
+
+    assert settings.auth_security_redis_url == "redis://dedicated.invalid:6379/0"
+
+
+def test_auth_security_redis_url_reuses_legacy_shared_etl_setting() -> None:
+    settings = Settings(
+        _env_file=None,
+        APP_ENV="test",
+        ETL_REDIS_URL="redis://legacy-etl.invalid:6379/0",
+    )
+
+    assert settings.auth_security_redis_url == "redis://legacy-etl.invalid:6379/0"
+
+
+def test_auth_security_redis_url_prefers_legacy_rate_limit_over_etl() -> None:
+    settings = Settings(
+        _env_file=None,
+        APP_ENV="test",
+        RATELIMIT_REDIS_URL="redis://legacy-rate-limit.invalid:6379/0",
+        ETL_REDIS_URL="redis://legacy-etl.invalid:6379/0",
+    )
+
+    assert settings.auth_security_redis_url == "redis://legacy-rate-limit.invalid:6379/0"


### PR DESCRIPTION
<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
