### PR TITLE
fix(git): allow first cache rebuild

### DIFF
--- a/backend/scripts/railway_smoke.py
+++ b/backend/scripts/railway_smoke.py
@@ -9,10 +9,9 @@ exercises the deployed V2 surface end-to-end:
   4. bulk_write — multi-file atomicity
   5. Move + delete
   6. List + tree + stat
-  7. Health endpoint (project root + AP — both four states reachable
-     here? at least healthy + empty)
+  7. Human control-plane Git-view health endpoint (JWT + repository contract)
   8. Conflict pending list (should be empty for fresh project)
-  9. Shadow snapshot upsert (small) + 413 boundary
+  9. Shadow snapshot upsert (small) + 100,000-entry 413 boundary
  10. Rebuild-cache endpoint (project root)
  11. Cleanup — delete the temp project
 
@@ -45,6 +44,7 @@ import httpx
 
 API = os.environ.get("PUPPYONE_API_URL", "https://qubits-api.puppyone.ai").rstrip("/")
 TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+REPOSITORY_CONTRACT_HEADERS = {"X-PuppyOne-Repository-Contract": "2"}
 
 
 def _load_token() -> str:
@@ -168,7 +168,10 @@ class Smoke:
 
     def step_initial_health(self):
         def run():
-            r = self.client.get(f"/git/{self.test_project_id}.git/health")
+            r = self.client.get(
+                f"/api/v1/projects/{self.test_project_id}/git-view/health",
+                headers=REPOSITORY_CONTRACT_HEADERS,
+            )
             body = self._expect_ok(r, hint="project health (empty)")
             data = body.get("data", {})
             state = data.get("health")
@@ -278,7 +281,10 @@ class Smoke:
 
     def step_health_after_writes(self):
         def run():
-            r = self.client.get(f"/git/{self.test_project_id}.git/health")
+            r = self.client.get(
+                f"/api/v1/projects/{self.test_project_id}/git-view/health",
+                headers=REPOSITORY_CONTRACT_HEADERS,
+            )
             body = self._expect_ok(r, hint="health after writes")
             data = body.get("data", {})
             state = data.get("health")
@@ -356,23 +362,27 @@ class Smoke:
 
     def step_shadow_snapshot_413(self):
         def run():
-            # Pack 20 MB of preview text — past the 8 MiB cap.
-            big = "x" * (20 * 1024 * 1024)
+            # JSONB size was intentionally retired when manifests moved to
+            # S3.  The product contract is now a 100,000-entry guard, which
+            # avoids treating a valid large text preview as an invalid
+            # snapshot.  Unique paths make this reach the semantic cap rather
+            # than a duplicate-path validator.
+            manifest = [
+                {
+                    "path": f"shadow/cap/{index}.txt",
+                    "mode": "100644",
+                    "blob_hash": "b" * 40,
+                    "size": 1,
+                }
+                for index in range(100_001)
+            ]
             r = self.client.post(
                 "/api/v1/local-snapshots",
                 json={
                     "project_id": self.test_project_id,
                     "machine_id": "smoke-host-413",
                     "ref_name": "main",
-                    "manifest": [
-                        {
-                            "path": "shadow/huge.md",
-                            "mode": "100644",
-                            "blob_hash": "b" * 40,
-                            "size": 23,
-                            "preview": big,
-                        },
-                    ],
+                    "manifest": manifest,
                 },
             )
             assert r.status_code == 413, (
@@ -391,7 +401,7 @@ class Smoke:
             cap = detail.get("cap") if isinstance(detail, dict) else None
             assert limit, f"413 body missing structured limit field: {self._resp_text(r)}"
             return f"413 limit={limit!r} actual={actual} cap={cap}"
-        self.step("14. Shadow snapshot 8 MiB cap → HTTP 413", run)
+        self.step("14. Shadow snapshot 100k-entry cap → HTTP 413", run)
 
     def step_shadow_list(self):
         def run():
@@ -410,7 +420,8 @@ class Smoke:
     def step_rebuild_cache(self):
         def run():
             r = self.client.post(
-                f"/git/{self.test_project_id}.git/rebuild-cache",
+                f"/api/v1/projects/{self.test_project_id}/git-view/rebuild-cache",
+                headers=REPOSITORY_CONTRACT_HEADERS,
             )
             # Read-only members might be refused; allow 200 or 403.
             if r.status_code == 403:
@@ -433,7 +444,10 @@ class Smoke:
             if r.status_code == 202:
                 status = (r.json().get("data") or {}).get("status", "pending")
                 return f"deletion accepted for {self.test_project_id} ({status})"
-            return f"cleanup HTTP {r.status_code}: {self._resp_text(r)}"
+            raise AssertionError(
+                "cleanup must be accepted by the deployment; "
+                f"got HTTP {r.status_code}: {self._resp_text(r)}"
+            )
         self.step("17. Cleanup — delete temp project", run)
 
     def stress_move_health_race(self, iterations: int = 12):
@@ -487,7 +501,10 @@ class Smoke:
                     json={"old_path": "x0.md", "new_path": "renamed-x0.md"},
                 )
                 # immediate health check
-                h = self.client.get(f"/git/{pid}.git/health")
+                h = self.client.get(
+                    f"/api/v1/projects/{pid}/git-view/health",
+                    headers=REPOSITORY_CONTRACT_HEADERS,
+                )
                 state = h.json().get("data", {}).get("health")
                 git_usable = h.json().get("data", {}).get("git_usable")
                 marker = "  ✓" if state in {"healthy", "history_degraded"} else "  ✗"

--- a/backend/src/version_engine/adapters/git/view_cache.py
+++ b/backend/src/version_engine/adapters/git/view_cache.py
@@ -261,7 +261,15 @@ def invalidate_git_view_cache(key: GitViewCacheKey) -> None:
     with try_file_exclusive_lock(view_lock_path(cache_dir)) as acquired:
         if not acquired:
             raise RuntimeError("git view cache is active and cannot be invalidated")
-        shutil.rmtree(cache_dir, ignore_errors=False)
+        # A rebuild is also the cache's first materialization path.  In that
+        # case there is deliberately nothing to remove.  The existence check
+        # must live *inside* the view lock: another rebuild may have removed
+        # the directory after the path was resolved but before this caller
+        # acquired the lock.  Do not use ``ignore_errors=True`` here; I/O and
+        # permission failures still need to surface instead of being mistaken
+        # for a successful cache invalidation.
+        if cache_dir.exists():
+            shutil.rmtree(cache_dir, ignore_errors=False)
 
 
 def object_store_namespace(repo) -> str:

--- a/backend/tests/security/test_audit_unit_fixes.py
+++ b/backend/tests/security/test_audit_unit_fixes.py
@@ -243,3 +243,78 @@ class TestViewCachePrune:
         assert oldest.exists()
         assert not second.exists(), "pruner must continue after a failed deletion"
         assert newest.exists()
+
+
+class TestGitViewCacheInvalidation:
+    def _key(self):
+        from src.version_engine.adapters.git.view_cache import GitViewCacheKey
+
+        return GitViewCacheKey(
+            project_id="project-1",
+            object_store="test-store",
+            scope_path="",
+            scope_excludes=(),
+            projection_version="git-view-v1",
+            history_mode="full",
+            blob_mode="included",
+        )
+
+    def test_missing_cache_is_a_valid_first_rebuild_state(self, tmp_path, monkeypatch):
+        """A first rebuild must not fail merely because there is no cache yet."""
+        from src.version_engine.adapters.git import view_cache
+
+        root = tmp_path / "cache"
+        monkeypatch.setattr(view_cache, "git_view_cache_root", lambda: root)
+
+        view_cache.invalidate_git_view_cache(self._key())
+
+        assert not self._key().cache_dir().exists()
+
+    def test_existing_cache_is_removed(self, tmp_path, monkeypatch):
+        from src.version_engine.adapters.git import view_cache
+
+        root = tmp_path / "cache"
+        monkeypatch.setattr(view_cache, "git_view_cache_root", lambda: root)
+        cache_dir = self._key().cache_dir()
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "view.json").write_text("{}", encoding="utf-8")
+
+        view_cache.invalidate_git_view_cache(self._key())
+
+        assert not cache_dir.exists()
+
+    def test_first_transport_rebuild_rewarms_without_a_prior_cache(
+        self, tmp_path, monkeypatch
+    ):
+        """The admin repair endpoint must work before a cache exists."""
+        from types import SimpleNamespace
+
+        from src.version_engine.adapters.git import view_cache
+        from src.version_engine.derived import git_transport_cache
+
+        root = tmp_path / "cache"
+        monkeypatch.setattr(view_cache, "git_view_cache_root", lambda: root)
+        calls = []
+
+        def fake_warm(repo, scope_path, scope_excludes, **kwargs):
+            calls.append((repo, scope_path, scope_excludes, kwargs))
+            return "new-canonical-head"
+
+        monkeypatch.setattr(
+            git_transport_cache, "warm_transport_bare_repo", fake_warm
+        )
+        repo = SimpleNamespace(
+            _project_id="project-1",
+            store=SimpleNamespace(dir=tmp_path / "object-store"),
+        )
+
+        result = git_transport_cache.rebuild_git_transport_view(
+            repo,
+            scope_path="",
+            scope_excludes=[],
+            follow_history=True,
+            include_blobs=True,
+        )
+
+        assert result["head"] == "new-canonical-head"
+        assert calls == [(repo, "", [], {"follow_history": True, "include_blobs": True})]

--- a/backend/tests/security/test_canonical_git_remote_contract.py
+++ b/backend/tests/security/test_canonical_git_remote_contract.py
@@ -266,6 +266,16 @@ def test_web_git_health_uses_human_control_plane_not_git_runtime_routes():
     assert "rebuildGitScopeCache" not in api
 
 
+def test_railway_smoke_uses_human_git_control_plane_and_current_snapshot_cap():
+    smoke = (ROOT / "backend/scripts/railway_smoke.py").read_text(encoding="utf-8")
+
+    assert "/api/v1/projects/{self.test_project_id}/git-view/health" in smoke
+    assert "/api/v1/projects/{self.test_project_id}/git-view/rebuild-cache" in smoke
+    assert "X-PuppyOne-Repository-Contract" in smoke
+    assert "range(100_001)" in smoke
+    assert "cleanup must be accepted by the deployment" in smoke
+
+
 def test_web_one_time_git_credential_is_bound_to_displayed_target_and_mode():
     panel = (
         ROOT / "frontend/app/(main)/projects/[projectId]/data/components/access-points/"


### PR DESCRIPTION
<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
