### PR TITLE
fix(ci): run data migration after optional repair skip

### DIFF
--- a/.github/workflows/migrate-production.yml
+++ b/.github/workflows/migrate-production.yml
@@ -152,7 +152,11 @@ jobs:
       operation: plan
 
   data_run:
-    if: needs.data_plan.result == 'success'
+    # Keep the protected production chain live when no optional repair is
+    # staged.  See the matching Qubits workflow for the skipped-job case.
+    if: >-
+      always() && needs.data_plan.result == 'success' &&
+      needs.resolve_data_release.result == 'success'
     needs:
       - data_plan
       - resolve_data_release
@@ -164,7 +168,9 @@ jobs:
       operation: run
 
   data_verify:
-    if: needs.data_run.result == 'success'
+    if: >-
+      always() && needs.data_run.result == 'success' &&
+      needs.resolve_data_release.result == 'success'
     needs:
       - data_run
       - resolve_data_release
@@ -177,7 +183,7 @@ jobs:
 
   deploy_after_data:
     name: Recheck Production schema after data migration
-    if: needs.data_verify.result == 'success'
+    if: always() && needs.data_verify.result == 'success'
     needs: data_verify
     uses: ./.github/workflows/_schema-deploy.yml
     secrets: inherit

--- a/.github/workflows/migrate-staging.yml
+++ b/.github/workflows/migrate-staging.yml
@@ -129,7 +129,12 @@ jobs:
       operation: plan
 
   data_run:
-    if: needs.data_plan.result == 'success'
+    # ``repair_run`` is intentionally optional.  A skipped optional ancestor
+    # otherwise propagates GitHub's implicit success() guard and silently
+    # skips this mutation even after data_plan succeeded.
+    if: >-
+      always() && needs.data_plan.result == 'success' &&
+      needs.resolve_data_release.result == 'success'
     needs:
       - data_plan
       - resolve_data_release
@@ -141,7 +146,9 @@ jobs:
       operation: run
 
   data_verify:
-    if: needs.data_run.result == 'success'
+    if: >-
+      always() && needs.data_run.result == 'success' &&
+      needs.resolve_data_release.result == 'success'
     needs:
       - data_run
       - resolve_data_release
@@ -154,7 +161,7 @@ jobs:
 
   deploy_after_data:
     name: Recheck staging schema after data migration
-    if: needs.data_verify.result == 'success'
+    if: always() && needs.data_verify.result == 'success'
     needs: data_verify
     uses: ./.github/workflows/_schema-deploy.yml
     secrets: inherit

--- a/backend/tests/infra/data_migrations/test_workflows.py
+++ b/backend/tests/infra/data_migrations/test_workflows.py
@@ -158,9 +158,13 @@ def test_staging_release_is_automatic_auditable_and_serial() -> None:
     assert "needs.repair_run.result == 'success'" in jobs["data_plan"]["if"]
     assert "needs.repair_run.result == 'skipped'" in jobs["data_plan"]["if"]
     assert jobs["data_run"]["needs"] == ["data_plan", "resolve_data_release"]
+    assert "always()" in jobs["data_run"]["if"]
+    assert "needs.data_plan.result == 'success'" in jobs["data_run"]["if"]
     assert jobs["data_verify"]["needs"] == ["data_run", "resolve_data_release"]
+    assert "always()" in jobs["data_verify"]["if"]
+    assert "needs.data_run.result == 'success'" in jobs["data_verify"]["if"]
     assert jobs["deploy_after_data"]["needs"] == "data_verify"
-    assert jobs["deploy_after_data"]["if"] == "needs.data_verify.result == 'success'"
+    assert jobs["deploy_after_data"]["if"] == "always() && needs.data_verify.result == 'success'"
     assert staging.count("uses: ./.github/workflows/_schema-deploy.yml") == 2
     assert staging.count("uses: ./.github/workflows/_data-migration.yml") == 4
     for operation in ("plan", "run", "verify"):
@@ -197,7 +201,11 @@ def test_production_release_is_automatic_and_requires_qubits_evidence() -> None:
         "staging_data_evidence",
         "resolve_data_release",
     ]
-    assert jobs["deploy_after_data"]["if"] == "needs.data_verify.result == 'success'"
+    assert "always()" in jobs["data_run"]["if"]
+    assert "needs.data_plan.result == 'success'" in jobs["data_run"]["if"]
+    assert "always()" in jobs["data_verify"]["if"]
+    assert "needs.data_run.result == 'success'" in jobs["data_verify"]["if"]
+    assert jobs["deploy_after_data"]["if"] == "always() && needs.data_verify.result == 'success'"
     assert production.count("uses: ./.github/workflows/_schema-deploy.yml") == 2
     assert production.count("uses: ./.github/workflows/_data-migration.yml") == 6
     assert re.fullmatch(r"[0-9A-Za-z_]+", release["migration_id"])


### PR DESCRIPTION
<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
