### PR TITLE
fix: close auth and hosted MCP contract gaps

### DIFF
--- a/.github/workflows/validate-migrations.yml
+++ b/.github/workflows/validate-migrations.yml
@@ -7,6 +7,20 @@ permissions:
   contents: read
 
 jobs:
+  railway_release_contract:
+    name: Validate Railway release contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate Qubits service inventory and database gate
+        run: python backend/scripts/check_railway_release_gate.py
+
   database_change_scope:
     name: Detect database changes
     runs-on: ubuntu-latest
@@ -201,6 +215,7 @@ jobs:
     name: Database validation result
     if: always()
     needs:
+      - railway_release_contract
       - database_change_scope
       - repository_policy
       - validate_local_database
@@ -213,6 +228,7 @@ jobs:
       POLICY_RESULT: ${{ needs.repository_policy.result }}
       LOCAL_DATABASE_RESULT: ${{ needs.validate_local_database.result }}
       RPC_LINT_RESULT: ${{ needs.lint_rpc_signatures.result }}
+      RAILWAY_RELEASE_RESULT: ${{ needs.railway_release_contract.result }}
     steps:
       - name: Publish one stable required-check result
         shell: bash
@@ -220,6 +236,10 @@ jobs:
           set -euo pipefail
           if [ "$CHANGE_SCOPE_RESULT" != "success" ]; then
             echo "::error::Database change detection failed."
+            exit 1
+          fi
+          if [ "$RAILWAY_RELEASE_RESULT" != "success" ]; then
+            echo "::error::Railway release contract validation failed."
             exit 1
           fi
           if [ "$DATABASE_CHANGED" != "true" ]; then

--- a/backend/README.md
+++ b/backend/README.md
@@ -261,6 +261,9 @@ Notion / GitHub / Google (Sheets, Gmail, Drive, Calendar, Docs) / Linear / Airta
 
 | 端点 | 说明 |
 |------|------|
+| `POST /api/v1/auth/desktop/start` | 启动 Desktop OAuth；必须提交 S256 PKCE challenge |
+| `POST /api/v1/auth/desktop/exchange` | 使用一次性 code、state、verifier 与原始 redirect URI 换取会话 |
+| `POST /api/v1/auth/logout` | 使用 `refresh_token` 撤销当前 Supabase session；已失效 token 幂等成功 |
 | `GET /api/v1/oauth/{provider}/authorize` | OAuth 授权 |
 | `GET /api/v1/oauth/{provider}/callback` | OAuth 回调 |
 | `GET /health` | 健康检查 |

--- a/backend/deploy/railway-qubits-services.json
+++ b/backend/deploy/railway-qubits-services.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "repository": "puppyone-ai/puppyone",
+  "branch": "qubits",
+  "root_directory": "backend",
+  "database_gate": {
+    "workflow_file": ".github/workflows/migrate-staging.yml",
+    "workflow_name": "Deploy Database to Qubits",
+    "wait_for_ci_required": true
+  },
+  "services": [
+    { "service_role": "api", "requires_qubits_schema": true },
+    { "service_role": "file_worker", "requires_qubits_schema": true },
+    { "service_role": "import_worker", "requires_qubits_schema": true },
+    { "service_role": "sync_worker", "requires_qubits_schema": true },
+    { "service_role": "mcp_server", "requires_qubits_schema": true }
+  ]
+}

--- a/backend/scripts/check_railway_release_gate.py
+++ b/backend/scripts/check_railway_release_gate.py
@@ -1,0 +1,95 @@
+"""Validate the repository half of the Qubits Railway database release gate.
+
+Railway's ``Wait for CI`` switch is external state and must be evidenced from
+the dashboard/API. This check prevents repository drift around that setting:
+the complete service-role inventory, source branch, database workflow, and the
+absence of per-service schema mutation all remain reviewable and repeatable.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_ROLES = {"api", "file_worker", "import_worker", "sync_worker", "mcp_server"}
+
+
+def validate_contract(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    manifest_path = repo_root / "backend/deploy/railway-qubits-services.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"cannot read Railway service manifest: {exc}"]
+
+    if manifest.get("schema_version") != 1:
+        errors.append("Railway service manifest schema_version must be 1")
+    if manifest.get("repository") != "puppyone-ai/puppyone":
+        errors.append("Railway service manifest must target puppyone-ai/puppyone")
+    if manifest.get("branch") != "qubits":
+        errors.append("Railway service manifest must target qubits")
+    if manifest.get("root_directory") not in {"backend", "/backend"}:
+        errors.append("Railway services must use backend as Root Directory")
+
+    gate = manifest.get("database_gate") or {}
+    if gate.get("workflow_file") != ".github/workflows/migrate-staging.yml":
+        errors.append("database gate must use migrate-staging.yml")
+    if gate.get("workflow_name") != "Deploy Database to Qubits":
+        errors.append("database gate workflow name drifted")
+    if gate.get("wait_for_ci_required") is not True:
+        errors.append("Wait for CI must remain required")
+
+    services = manifest.get("services")
+    if not isinstance(services, list):
+        errors.append("services must be a list")
+        services = []
+    roles = [item.get("service_role") for item in services if isinstance(item, dict)]
+    if len(roles) != len(set(roles)):
+        errors.append("Railway service roles must be unique")
+    if set(roles) != REQUIRED_ROLES:
+        errors.append(
+            "Railway service inventory must contain exactly: "
+            + ", ".join(sorted(REQUIRED_ROLES))
+        )
+    if any(item.get("requires_qubits_schema") is not True for item in services):
+        errors.append("every listed Railway service must require the Qubits schema gate")
+
+    workflow_path = repo_root / str(gate.get("workflow_file", ""))
+    try:
+        workflow = workflow_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"cannot read database workflow: {exc}")
+        workflow = ""
+    if "name: Deploy Database to Qubits" not in workflow:
+        errors.append("migrate-staging.yml must keep its stable workflow name")
+    if "branches:\n      - qubits" not in workflow:
+        errors.append("migrate-staging.yml must run on every qubits push")
+
+    railway_files = [repo_root / "backend/railway.toml", repo_root / "backend/nixpacks.toml"]
+    deployment_text = "\n".join(path.read_text(encoding="utf-8") for path in railway_files)
+    lowered = deployment_text.lower()
+    if "supabase db push" in lowered:
+        errors.append("Railway build/start config must not run supabase db push")
+    railway_toml = railway_files[0].read_text(encoding="utf-8")
+    for role in REQUIRED_ROLES - {"api"}:
+        if role not in railway_toml:
+            errors.append(f"backend/railway.toml does not route SERVICE_ROLE={role}")
+
+    return errors
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    errors = validate_contract(repo_root)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("Railway Qubits database release contract is internally consistent.")
+    print("Dashboard Wait for CI state still requires an external release receipt.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/src/connectors/manager/router.py
+++ b/backend/src/connectors/manager/router.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from pydantic import BaseModel, Field
 
 from src.common_schemas import ApiResponse
+from src.config import settings
 from src.exceptions import AppException, ErrorCode, NotFoundException
 from src.infra.supabase.client import SupabaseClient
 from src.platform.auth.dependencies import get_current_user
@@ -669,6 +670,19 @@ class UnifiedConnectionOut(BaseModel):
     git_username: str | None = None
     git_credential: str | None = None
     cli_access_key: str | None = None
+    mcp_api_key: str | None = Field(
+        None,
+        description="One-time MCP bearer credential returned only by creation",
+    )
+    mcp_server_url: str | None = Field(
+        None,
+        description="Canonical public MCP proxy URL; authenticate with Authorization: Bearer",
+    )
+
+
+def _public_mcp_server_url() -> str | None:
+    base = (settings.PUBLIC_URL or "").rstrip("/")
+    return f"{base}/api/v1/mcp/proxy" if base else None
 
 
 def _create_agent(payload: UnifiedConnectionCreate) -> UnifiedConnectionOut:
@@ -708,6 +722,8 @@ def _create_agent(payload: UnifiedConnectionCreate) -> UnifiedConnectionOut:
         provider="agent",
         name=agent.name,
         status="active",
+        mcp_api_key=agent.mcp_api_key,
+        mcp_server_url=_public_mcp_server_url(),
     )
 
 
@@ -738,6 +754,8 @@ def _create_mcp(
         provider="mcp",
         name=row["name"],
         status=row["status"],
+        mcp_api_key=row.get("api_key"),
+        mcp_server_url=_public_mcp_server_url(),
     )
 
 

--- a/backend/src/infra/data_migrations/catalog.py
+++ b/backend/src/infra/data_migrations/catalog.py
@@ -177,8 +177,8 @@ class DataMigrationCatalog:
         digest = hashlib.sha256()
         for relative_name, content in (
             ("manifest", canonical_manifest),
-            (manifest.entrypoint, entrypoint_path.read_bytes()),
-            (manifest.verify, verify_path.read_bytes()),
+            (manifest.entrypoint, _canonical_text_bytes(entrypoint_path)),
+            (manifest.verify, _canonical_text_bytes(verify_path)),
         ):
             digest.update(relative_name.encode())
             digest.update(b"\0")
@@ -229,3 +229,9 @@ class DataMigrationCatalog:
                     f"Python data migration cannot import mutable application package "
                     f"{sorted(forbidden)[0]}: {entrypoint_path}"
                 )
+
+
+def _canonical_text_bytes(path: Path) -> bytes:
+    """Make immutable artifact checksums independent of Git checkout EOLs."""
+
+    return path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")

--- a/backend/src/platform/auth/router.py
+++ b/backend/src/platform/auth/router.py
@@ -3,6 +3,7 @@ Auth router — for CLI / external clients
 
 POST   /auth/login           Sign in with email + password, returns access_token
 POST   /auth/refresh         Refresh access_token
+POST   /auth/logout          Revoke the refresh-token session (idempotent)
 POST   /auth/initialize      Idempotent user initialization (profile + org)
 POST   /auth/check-email     Check if email is already registered (rate-limited)
 GET    /auth/config           Public Supabase config (URL + anon key) for Realtime
@@ -20,7 +21,7 @@ from urllib.parse import urlencode, urlparse
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, SecretStr
 from supabase import create_client
 
 from src.common_schemas import ApiResponse
@@ -85,6 +86,16 @@ class LoginResponse(BaseModel):
 
 class RefreshRequest(BaseModel):
     refresh_token: str
+
+
+class LogoutRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    refresh_token: SecretStr = Field(min_length=1, max_length=8192)
+
+
+class LogoutResponse(BaseModel):
+    revoked: bool
 
 
 class CheckEmailRequest(BaseModel):
@@ -162,9 +173,7 @@ _DESKTOP_LOOPBACK_PATH = "/auth/callback"
 def _validate_desktop_code_challenge(
     code_challenge: str | None,
     code_challenge_method: str | None,
-) -> str | None:
-    if code_challenge is None and code_challenge_method is None:
-        return None
+) -> str:
     challenge = (code_challenge or "").strip()
     method = (code_challenge_method or "").strip().upper()
     if method != "S256" or not _DESKTOP_PKCE_VALUE.fullmatch(challenge):
@@ -280,7 +289,7 @@ def desktop_auth_start(
     )
     callback_url = _validate_desktop_callback(
         body.callback_url,
-        allow_loopback=desktop_code_challenge is not None,
+        allow_loopback=True,
     )
     state = secrets.token_urlsafe(32)
     pending = {
@@ -595,6 +604,74 @@ def refresh_token(body: RefreshRequest):
         raise
     except Exception as e:
         raise HTTPException(status_code=401, detail=f"Refresh failed: {e!s}")
+
+
+@router.post("/logout", response_model=ApiResponse[LogoutResponse])
+async def logout(body: LogoutRequest):
+    """Revoke the Supabase session identified by a refresh token.
+
+    Desktop can hold a refresh token after its access JWT expires, while the
+    upstream logout endpoint requires a current access JWT. Rotate the supplied
+    refresh token once, then revoke that exact session with ``scope=local``.
+    Invalid/already-revoked tokens are an idempotent success; provider outages
+    remain visible so the client can report remote-revoke failure while still
+    completing its unconditional local logout.
+    """
+    refresh_value = body.refresh_token.get_secret_value().strip()
+    if not refresh_value:
+        raise HTTPException(status_code=400, detail="Refresh token is required")
+
+    supabase_url = os.environ.get("SUPABASE_URL", "").rstrip("/")
+    api_key = os.environ.get("SUPABASE_ANON_KEY", "") or os.environ.get("SUPABASE_KEY", "")
+    if not supabase_url or not api_key:
+        raise HTTPException(status_code=503, detail="Authentication provider is not configured")
+
+    provider_headers = {
+        "apikey": api_key,
+        "Content-Type": "application/json",
+    }
+    try:
+        async with httpx.AsyncClient() as client:
+            refreshed = await client.post(
+                f"{supabase_url}/auth/v1/token?grant_type=refresh_token",
+                headers=provider_headers,
+                json={"refresh_token": refresh_value},
+            )
+            if refreshed.status_code in {400, 401, 403}:
+                return ApiResponse.success(data=LogoutResponse(revoked=True))
+            if refreshed.status_code != 200:
+                raise HTTPException(status_code=502, detail="Authentication provider unavailable")
+            try:
+                access_token = str(refreshed.json().get("access_token", "")).strip()
+            except (TypeError, ValueError) as exc:
+                raise HTTPException(
+                    status_code=502,
+                    detail="Authentication provider returned an invalid session",
+                ) from exc
+            if not access_token:
+                raise HTTPException(
+                    status_code=502,
+                    detail="Authentication provider returned an invalid session",
+                )
+
+            revoked = await client.post(
+                f"{supabase_url}/auth/v1/logout?scope=local",
+                headers={
+                    **provider_headers,
+                    "Authorization": f"Bearer {access_token}",
+                },
+            )
+            if not (200 <= revoked.status_code < 300) and revoked.status_code not in {
+                401,
+                403,
+            }:
+                raise HTTPException(status_code=502, detail="Authentication provider unavailable")
+    except HTTPException:
+        raise
+    except httpx.HTTPError as exc:
+        raise HTTPException(status_code=502, detail="Authentication provider unavailable") from exc
+
+    return ApiResponse.success(data=LogoutResponse(revoked=True))
 
 
 class InitializeResponse(BaseModel):

--- a/backend/src/platform/landing/schemas.py
+++ b/backend/src/platform/landing/schemas.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+LANDING_CONTRACT_VERSION = 1
 
 
 class PreviewInfo(BaseModel):
@@ -15,6 +19,7 @@ class PreviewInfo(BaseModel):
 
 
 class PreviewResponse(BaseModel):
+    contract_version: Literal[1] = LANDING_CONTRACT_VERSION
     ticket: str = Field(..., description="Signed capability ticket to present at /landing/claim")
     preview: PreviewInfo
     expires_at: int = Field(..., description="Unix epoch seconds when the ticket/preview expires")
@@ -23,6 +28,7 @@ class PreviewResponse(BaseModel):
 class ClaimRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    contract_version: Literal[1] = LANDING_CONTRACT_VERSION
     ticket: str = Field(min_length=1, max_length=8192)
     org_id: str = Field(min_length=1, max_length=128)
 
@@ -42,6 +48,7 @@ class ClaimMcp(BaseModel):
 
 
 class ClaimResponse(BaseModel):
+    contract_version: Literal[1] = LANDING_CONTRACT_VERSION
     project_id: str
     repo: str = Field(..., description="Scope/folder path the content lives under")
     mcp: ClaimMcp

--- a/backend/tests/auth/test_desktop_auth_flow.py
+++ b/backend/tests/auth/test_desktop_auth_flow.py
@@ -93,7 +93,12 @@ async def test_desktop_oauth_pkce_state_and_exchange_are_single_use(monkeypatch)
     monkeypatch.setattr(auth_router.httpx, "AsyncClient", lambda: client)
 
     started = auth_router.desktop_auth_start(
-        auth_router.DesktopStartRequest(provider="github", callback_url=CALLBACK_URL),
+        auth_router.DesktopStartRequest(
+            provider="github",
+            callback_url=CALLBACK_URL,
+            code_challenge=DESKTOP_CHALLENGE,
+            code_challenge_method="S256",
+        ),
         store=store,
     )
     state = started.data.state
@@ -123,14 +128,24 @@ async def test_desktop_oauth_pkce_state_and_exchange_are_single_use(monkeypatch)
     assert ("desktop-state", state) not in store.values
 
     exchanged = auth_router.desktop_auth_exchange(
-        auth_router.DesktopExchangeRequest(code=exchange_code, state=state),
+        auth_router.DesktopExchangeRequest(
+            code=exchange_code,
+            state=state,
+            code_verifier=DESKTOP_VERIFIER,
+            redirect_uri=CALLBACK_URL,
+        ),
         store=store,
     )
     assert exchanged.data["access_token"] == "access-token"
 
     with pytest.raises(HTTPException) as replay:
         auth_router.desktop_auth_exchange(
-            auth_router.DesktopExchangeRequest(code=exchange_code, state=state),
+            auth_router.DesktopExchangeRequest(
+                code=exchange_code,
+                state=state,
+                code_verifier=DESKTOP_VERIFIER,
+                redirect_uri=CALLBACK_URL,
+            ),
             store=store,
         )
     assert replay.value.status_code == 400
@@ -380,6 +395,18 @@ def test_desktop_loopback_callback_requires_pkce():
     assert missing_pkce.value.status_code == 400
 
 
+def test_desktop_allowlisted_callback_still_requires_pkce():
+    with pytest.raises(HTTPException) as missing_pkce:
+        auth_router.desktop_auth_start(
+            auth_router.DesktopStartRequest(
+                provider="github",
+                callback_url=CALLBACK_URL,
+            ),
+            store=_MemorySecurityStore(),
+        )
+    assert missing_pkce.value.status_code == 400
+
+
 @pytest.mark.parametrize(
     ("challenge", "method"),
     [
@@ -418,7 +445,12 @@ def test_desktop_start_fails_closed_when_shared_store_is_unavailable():
 
     with pytest.raises(HTTPException) as unavailable:
         auth_router.desktop_auth_start(
-            auth_router.DesktopStartRequest(provider="google", callback_url=CALLBACK_URL),
+            auth_router.DesktopStartRequest(
+                provider="google",
+                callback_url=CALLBACK_URL,
+                code_challenge=DESKTOP_CHALLENGE,
+                code_challenge_method="S256",
+            ),
             store=_UnavailableStore(),
         )
     assert unavailable.value.status_code == 503

--- a/backend/tests/auth/test_logout.py
+++ b/backend/tests/auth/test_logout.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from src.platform.auth import router as auth_router
+
+
+class _Response:
+    def __init__(self, status_code: int, payload: dict | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self) -> dict:
+        return dict(self._payload)
+
+
+class _SessionProvider:
+    def __init__(self) -> None:
+        self.refresh_sessions = {"refresh-old": "session-1"}
+        self.access_sessions: dict[str, str] = {}
+        self.calls: list[tuple[str, dict, dict | None]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args) -> None:
+        return None
+
+    async def post(self, url: str, *, headers: dict, json: dict | None = None):
+        self.calls.append((url, headers, json))
+        if "grant_type=refresh_token" in url:
+            refresh_token = str((json or {}).get("refresh_token", ""))
+            session_id = self.refresh_sessions.get(refresh_token)
+            if session_id is None:
+                return _Response(400, {"error_code": "refresh_token_not_found"})
+            access_token = f"access-{session_id}"
+            # Model Supabase's refresh-token reuse window: both the submitted
+            # token and its child remain usable until the session is revoked.
+            self.refresh_sessions["refresh-child"] = session_id
+            self.access_sessions[access_token] = session_id
+            return _Response(
+                200,
+                {
+                    "access_token": access_token,
+                    "refresh_token": "refresh-child",
+                    "expires_in": 3600,
+                },
+            )
+
+        assert url.endswith("/auth/v1/logout?scope=local")
+        access_token = headers.get("Authorization", "").removeprefix("Bearer ")
+        session_id = self.access_sessions.pop(access_token, None)
+        if session_id is None:
+            return _Response(401)
+        self.refresh_sessions = {
+            token: owner
+            for token, owner in self.refresh_sessions.items()
+            if owner != session_id
+        }
+        return _Response(204)
+
+    def sdk_refresh(self, refresh_token: str):
+        if refresh_token not in self.refresh_sessions:
+            raise RuntimeError("refresh token not found")
+        return SimpleNamespace(
+            session=SimpleNamespace(
+                access_token="unexpected",
+                refresh_token="unexpected",
+                expires_in=3600,
+            ),
+            user=SimpleNamespace(email="user@example.com"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_logout_revokes_session_and_old_refresh_token_cannot_replay(monkeypatch) -> None:
+    provider = _SessionProvider()
+    monkeypatch.setenv("SUPABASE_URL", "https://auth.example.test")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "anon-key")
+    monkeypatch.setattr(auth_router.httpx, "AsyncClient", lambda: provider)
+
+    result = await auth_router.logout(
+        auth_router.LogoutRequest(refresh_token="refresh-old")
+    )
+
+    assert result.data.revoked is True
+    assert [call[0] for call in provider.calls] == [
+        "https://auth.example.test/auth/v1/token?grant_type=refresh_token",
+        "https://auth.example.test/auth/v1/logout?scope=local",
+    ]
+    assert provider.calls[1][1]["Authorization"] == "Bearer access-session-1"
+    assert "refresh-old" not in provider.calls[1][1]["Authorization"]
+
+    monkeypatch.setattr(
+        auth_router,
+        "_make_auth_client",
+        lambda: SimpleNamespace(
+            auth=SimpleNamespace(refresh_session=provider.sdk_refresh)
+        ),
+    )
+    with pytest.raises(HTTPException) as replay:
+        auth_router.refresh_token(auth_router.RefreshRequest(refresh_token="refresh-old"))
+    assert replay.value.status_code == 401
+    with pytest.raises(HTTPException):
+        auth_router.refresh_token(auth_router.RefreshRequest(refresh_token="refresh-child"))
+
+
+@pytest.mark.asyncio
+async def test_logout_is_idempotent_for_an_already_invalid_refresh_token(monkeypatch) -> None:
+    provider = _SessionProvider()
+    monkeypatch.setenv("SUPABASE_URL", "https://auth.example.test")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "anon-key")
+    monkeypatch.setattr(auth_router.httpx, "AsyncClient", lambda: provider)
+
+    result = await auth_router.logout(
+        auth_router.LogoutRequest(refresh_token="already-invalid")
+    )
+
+    assert result.data.revoked is True
+    assert len(provider.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_logout_surfaces_provider_outage_without_echoing_refresh_token(monkeypatch) -> None:
+    refresh_token = "refresh-do-not-echo"
+
+    class OfflineProvider:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args) -> None:
+            return None
+
+        async def post(self, *_args, **_kwargs):
+            raise httpx.ConnectError("offline")
+
+    monkeypatch.setenv("SUPABASE_URL", "https://auth.example.test")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "anon-key")
+    monkeypatch.setattr(auth_router.httpx, "AsyncClient", OfflineProvider)
+
+    with pytest.raises(HTTPException) as unavailable:
+        await auth_router.logout(auth_router.LogoutRequest(refresh_token=refresh_token))
+
+    assert unavailable.value.status_code == 502
+    assert refresh_token not in str(unavailable.value.detail)

--- a/backend/tests/connectors/test_unified_mcp_creation_contract.py
+++ b/backend/tests/connectors/test_unified_mcp_creation_contract.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+from src.config import settings
+from src.connectors.manager.router import UnifiedConnectionCreate, _create_agent, _create_mcp
+
+
+def test_unified_mcp_create_returns_one_time_bearer_contract(monkeypatch) -> None:
+    issued = "mcp_one_time_secret"
+
+    class Service:
+        def __init__(self, repository) -> None:
+            self.repository = repository
+
+        def create_endpoint(self, **kwargs):
+            return {
+                "id": "endpoint-1",
+                "project_id": kwargs["project_id"],
+                "name": kwargs["name"],
+                "status": "active",
+                "api_key": issued,
+            }
+
+    monkeypatch.setattr(
+        "src.connectors.mcp_endpoint.repository.McpEndpointRepository",
+        lambda: object(),
+    )
+    monkeypatch.setattr("src.connectors.mcp_endpoint.service.McpEndpointService", Service)
+    monkeypatch.setattr(settings, "PUBLIC_URL", "https://api.example.test/")
+
+    result = _create_mcp(
+        UnifiedConnectionCreate(
+            project_id="project-1",
+            provider="mcp",
+            name="Docs",
+        ),
+        created_by="user-1",
+    )
+
+    assert result.mcp_api_key == issued
+    assert result.mcp_server_url == "https://api.example.test/api/v1/mcp/proxy"
+    assert issued not in result.mcp_server_url
+
+
+def test_unified_agent_create_preserves_one_time_mcp_bearer(monkeypatch) -> None:
+    issued = "mcp_agent_one_time_secret"
+
+    class Service:
+        def __init__(self, repository) -> None:
+            self.repository = repository
+
+        def create_agent(self, **kwargs):
+            return SimpleNamespace(
+                id="agent-1",
+                name=kwargs["name"],
+                mcp_api_key=issued,
+            )
+
+    monkeypatch.setattr(
+        "src.connectors.agent.config.repository.AgentRepository",
+        lambda: object(),
+    )
+    monkeypatch.setattr("src.connectors.agent.config.service.AgentConfigService", Service)
+    monkeypatch.setattr(settings, "PUBLIC_URL", "https://api.example.test")
+
+    result = _create_agent(
+        UnifiedConnectionCreate(
+            project_id="project-1",
+            provider="agent",
+            name="Assistant",
+        )
+    )
+
+    assert result.mcp_api_key == issued
+    assert result.mcp_server_url == "https://api.example.test/api/v1/mcp/proxy"

--- a/backend/tests/infra/data_migrations/test_catalog.py
+++ b/backend/tests/infra/data_migrations/test_catalog.py
@@ -107,10 +107,15 @@ def test_data_migration_directory_cannot_be_a_symlink(tmp_path: Path) -> None:
     repository = _repository(tmp_path)
     outside = repository / "outside_migration"
     outside.mkdir()
-    (repository / "supabase/data_migrations/20260713_link").symlink_to(
-        outside,
-        target_is_directory=True,
-    )
+    try:
+        (repository / "supabase/data_migrations/20260713_link").symlink_to(
+            outside,
+            target_is_directory=True,
+        )
+    except OSError as error:
+        if getattr(error, "winerror", None) == 1314:
+            pytest.skip("Windows account cannot create the symlink attack fixture")
+        raise
 
     with pytest.raises(ManifestError, match="cannot be symlinks"):
         DataMigrationCatalog(repository).load_all()

--- a/backend/tests/infra/data_migrations/test_catalog.py
+++ b/backend/tests/infra/data_migrations/test_catalog.py
@@ -70,6 +70,21 @@ def test_checksum_changes_when_executable_content_changes(tmp_path: Path) -> Non
     assert catalog.get("20260712_example").checksum != original
 
 
+def test_checksum_is_stable_across_line_endings(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    migration = repository / "supabase/data_migrations/20260712_example"
+    for name in ("run.sql", "verify.sql"):
+        migration.joinpath(name).write_bytes(b"SELECT 1;\n")
+
+    catalog = DataMigrationCatalog(repository)
+    original = catalog.get("20260712_example").checksum
+
+    for name in ("run.sql", "verify.sql"):
+        migration.joinpath(name).write_bytes(b"SELECT 1;\r\n")
+
+    assert catalog.get("20260712_example").checksum == original
+
+
 def test_manifest_cannot_escape_its_versioned_directory(tmp_path: Path) -> None:
     repository = _repository(tmp_path, entrypoint="../run.sql")
 

--- a/backend/tests/platform/test_cloud_project_publish_contract.py
+++ b/backend/tests/platform/test_cloud_project_publish_contract.py
@@ -13,8 +13,9 @@ CONTRACT_PATH = (
 
 def test_cloud_project_publish_contract_is_the_cross_repo_v1_fixture() -> None:
     payload = CONTRACT_PATH.read_bytes()
+    canonical_payload = payload.replace(b"\r\n", b"\n")
 
-    assert hashlib.sha256(payload).hexdigest() == CONTRACT_SHA256
+    assert hashlib.sha256(canonical_payload).hexdigest() == CONTRACT_SHA256
     contract = json.loads(payload)
     assert contract["contract"] == "puppyone.cloud-project-publish"
     assert contract["version"] == 1

--- a/backend/tests/platform/test_landing_claim_publication.py
+++ b/backend/tests/platform/test_landing_claim_publication.py
@@ -157,6 +157,12 @@ def test_claim_request_requires_an_explicit_nonblank_organization() -> None:
     assert ClaimRequest(ticket="signed", org_id=" org-1 ").org_id == "org-1"
 
 
+def test_claim_request_rejects_unknown_landing_contract_version() -> None:
+    assert ClaimRequest(ticket="signed", org_id="org-1").contract_version == 1
+    with pytest.raises(ValidationError, match="contract_version"):
+        ClaimRequest(ticket="signed", org_id="org-1", contract_version=2)
+
+
 def test_ticket_signature_and_expiry_can_be_checked_separately(monkeypatch) -> None:
     monkeypatch.setattr(settings, "JWT_SECRET", "landing-test-secret")
     ticket, _ = _ticket(expires_at=int(time.time()) - 60)

--- a/backend/tests/release/test_railway_release_gate_contract.py
+++ b/backend/tests/release/test_railway_release_gate_contract.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from scripts.check_railway_release_gate import REQUIRED_ROLES, validate_contract
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_railway_release_gate_repository_contract_is_consistent() -> None:
+    assert validate_contract(REPO_ROOT) == []
+
+
+def test_railway_release_gate_covers_every_backend_service_role() -> None:
+    railway = (REPO_ROOT / "backend/railway.toml").read_text(encoding="utf-8")
+    assert {"api", "file_worker", "import_worker", "sync_worker", "mcp_server"} == REQUIRED_ROLES
+    assert all(role == "api" or role in railway for role in REQUIRED_ROLES)

--- a/backend/tests/security/test_audit_rate_limit.py
+++ b/backend/tests/security/test_audit_rate_limit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import time
 from copy import deepcopy
 from threading import Lock
@@ -14,6 +16,11 @@ from fastapi.testclient import TestClient
 from src.config import settings
 from src.platform.auth import router as auth_router
 from src.platform.auth.shared_security_store import get_auth_security_store
+
+DESKTOP_VERIFIER = "desktop-verifier-abcdefghijklmnopqrstuvwxyz-0123456789-ABCDEFG"
+DESKTOP_CHALLENGE = base64.urlsafe_b64encode(
+    hashlib.sha256(DESKTOP_VERIFIER.encode("ascii")).digest()
+).rstrip(b"=").decode("ascii")
 
 
 class _SharedStore:
@@ -84,7 +91,12 @@ def test_desktop_oauth_crosses_instances_and_rejects_replay(monkeypatch):
 
     started = first.post(
         "/auth/desktop/start",
-        json={"provider": "google", "callback_url": "puppyone://auth/callback"},
+        json={
+            "provider": "google",
+            "callback_url": "puppyone://auth/callback",
+            "code_challenge": DESKTOP_CHALLENGE,
+            "code_challenge_method": "S256",
+        },
     ).json()["data"]
     state = started["state"]
     assert started["login_url"].startswith("https://login.example.com/auth/v1/authorize?")
@@ -101,13 +113,23 @@ def test_desktop_oauth_crosses_instances_and_rejects_replay(monkeypatch):
 
     exchanged = first.post(
         "/auth/desktop/exchange",
-        json={"code": exchange_code, "state": state},
+        json={
+            "code": exchange_code,
+            "state": state,
+            "code_verifier": DESKTOP_VERIFIER,
+            "redirect_uri": "puppyone://auth/callback",
+        },
     )
     assert exchanged.status_code == 200
     assert exchanged.json()["data"]["access_token"] == "access"
     assert second.post(
         "/auth/desktop/exchange",
-        json={"code": exchange_code, "state": state},
+        json={
+            "code": exchange_code,
+            "state": state,
+            "code_verifier": DESKTOP_VERIFIER,
+            "redirect_uri": "puppyone://auth/callback",
+        },
     ).status_code == 400
     assert first.get(
         "/auth/desktop/callback",
@@ -116,7 +138,12 @@ def test_desktop_oauth_crosses_instances_and_rejects_replay(monkeypatch):
 
     expired = first.post(
         "/auth/desktop/start",
-        json={"provider": "google", "callback_url": "puppyone://auth/callback"},
+        json={
+            "provider": "google",
+            "callback_url": "puppyone://auth/callback",
+            "code_challenge": DESKTOP_CHALLENGE,
+            "code_challenge_method": "S256",
+        },
     ).json()["data"]["state"]
     value, _deadline = store.values[("desktop-state", expired)]
     store.values[("desktop-state", expired)] = (value, 0)

--- a/backend/tests/sync/test_materializers.py
+++ b/backend/tests/sync/test_materializers.py
@@ -299,7 +299,7 @@ class _EngineMaterializerV2:
 
 
 @pytest.mark.asyncio
-async def test_integration_engine_uses_pinned_materializer(monkeypatch):
+async def test_integration_engine_uses_pinned_materializer():
     registry = ConnectorRegistry()
     registry.register(_EngineConnector())
     registry.register_materializer(_EngineMaterializer())
@@ -320,25 +320,18 @@ async def test_integration_engine_uses_pinned_materializer(monkeypatch):
     run_repo = MagicMock()
     run_repo.create.return_value = run
 
-    write_result = SimpleNamespace(commit_id="commit-2")
-    commands = MagicMock()
-    commands.bulk_write = AsyncMock(return_value=SimpleNamespace(result=write_result))
-    commands.write_bytes = AsyncMock()
+    write_port = MagicMock()
+    write_port.write_plan = AsyncMock(
+        return_value=SimpleNamespace(commit_id="commit-2")
+    )
 
-    class _Container:
-        def write_commands(self):
-            return commands
+    result = await IntegrationEngine(
+        registry, repository, run_repo, write_port=write_port
+    ).execute(connection.id)
 
-    import src.version_engine.bootstrap.dependencies as deps
-
-    monkeypatch.setattr(deps, "build_worker_version_engine_container", lambda: _Container())
-
-    result = await IntegrationEngine(registry, repository, run_repo).execute(connection.id)
-
-    commands.write_bytes.assert_not_called()
-    commands.bulk_write.assert_awaited_once()
-    call = commands.bulk_write.await_args
-    assert set(call.args[1]) == {
+    write_port.write_plan.assert_awaited_once()
+    call = write_port.write_plan.await_args
+    assert set(call.kwargs["plan"].files) == {
         "Integrations/Mount/index.json",
         "Integrations/Mount/docs/item.md",
     }
@@ -375,7 +368,7 @@ async def test_integration_engine_direct_execute_skips_existing_active_run():
 
 
 @pytest.mark.asyncio
-async def test_integration_engine_direct_execute_creates_claims_and_completes_run(monkeypatch):
+async def test_integration_engine_direct_execute_creates_claims_and_completes_run():
     run_repo = _CreatedSingleLaneRunRepo()
     connector = _ClaimAwareConnector(run_repo)
     registry = ConnectorRegistry()
@@ -392,20 +385,14 @@ async def test_integration_engine_direct_execute_creates_claims_and_completes_ru
     repository = MagicMock()
     repository.get_by_id.return_value = connection
 
-    write_result = SimpleNamespace(commit_id="commit-claim")
-    commands = MagicMock()
-    commands.bulk_write = AsyncMock(return_value=SimpleNamespace(result=write_result))
-    commands.write_bytes = AsyncMock()
+    write_port = MagicMock()
+    write_port.write_plan = AsyncMock(
+        return_value=SimpleNamespace(commit_id="commit-claim")
+    )
 
-    class _Container:
-        def write_commands(self):
-            return commands
-
-    import src.version_engine.bootstrap.dependencies as deps
-
-    monkeypatch.setattr(deps, "build_worker_version_engine_container", lambda: _Container())
-
-    result = await IntegrationEngine(registry, repository, run_repo).execute(connection.id)
+    result = await IntegrationEngine(
+        registry, repository, run_repo, write_port=write_port
+    ).execute(connection.id)
 
     assert result is not None
     assert result["run_id"] == "run-created"
@@ -413,7 +400,7 @@ async def test_integration_engine_direct_execute_creates_claims_and_completes_ru
     assert run_repo.claimed == ["run-created"]
     assert run_repo.completed == [("run-created", "success", "Fetched")]
     assert connector.fetch_calls == 1
-    commands.bulk_write.assert_awaited_once()
+    write_port.write_plan.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/version_engine/test_connectors.py
+++ b/backend/tests/version_engine/test_connectors.py
@@ -6,13 +6,16 @@ Covers:
   - Unified connections manager routing by provider
 """
 
-import pytest
 from unittest.mock import MagicMock
 
-from src.connectors.datasource._base import (
-    BaseConnector, ConnectorSpec, FetchResult, Capability,
-)
+import pytest
 
+from src.connectors.datasource._base import (
+    BaseConnector,
+    Capability,
+    ConnectorSpec,
+    FetchResult,
+)
 
 # ── BaseConnector Tests ────────────────────────────────────────
 
@@ -119,6 +122,7 @@ class TestIntegrationEngineDecoupling:
     def test_engine_uses_version_write_port(self):
         """IntegrationEngine.execute() should enter project writes through one port."""
         import inspect
+
         from src.platform.integrations.engine import IntegrationEngine
         source = inspect.getsource(IntegrationEngine.execute)
         assert "self.write_port.write_plan" in source
@@ -128,10 +132,10 @@ class TestIntegrationEngineDecoupling:
     def test_version_write_port_uses_version_write_commands(self):
         """The Integration write port is the only direct Version Engine write adapter."""
         import inspect
+
         from src.platform.integrations.version_write_port import VersionEngineWritePort
         source = inspect.getsource(VersionEngineWritePort.write_plan)
-        assert "build_worker_version_engine_container" in source
-        assert "write_commands" in source
+        assert "build_leased_worker_write_commands" in source
         assert "commands.bulk_write" in source
         assert "commands.write_bytes" in source
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "bash tests/run.sh",
-    "test:unit": "node tests/fs_golden.test.mjs && node tests/fs_cli_mapping.test.mjs && node tests/template_commands.test.mjs",
+    "test:unit": "node tests/fs_golden.test.mjs && node tests/fs_cli_mapping.test.mjs && node tests/template_commands.test.mjs && node tests/mcp_config.test.mjs",
     "test:verbose": "bash tests/run.sh --verbose"
   },
   "files": [

--- a/cli/src/api.js
+++ b/cli/src/api.js
@@ -1,4 +1,5 @@
 import { resolveAuth, loadConfig, saveConfig, getTargetAuth, saveTargetAuth } from "./config.js";
+import { repositoryContractHeaders } from "./repository-contract.js";
 
 export class ApiError extends Error {
   constructor(status, code, message, hint, data) {
@@ -143,7 +144,10 @@ function _makeClient(apiUrl, authHeaders, { autoRefresh = false, clientKind = "c
   // backend reads it during version access resolution and rejects the request when the
   // matching connector for the resolved scope is paused. Threaded into
   // a single source so both `request` and `rawRequest` / `upload` agree.
-  const channelHeaders = clientKind ? { "X-Puppy-Client": clientKind } : {};
+  const channelHeaders = {
+    ...repositoryContractHeaders(),
+    ...(clientKind ? { "X-Puppy-Client": clientKind } : {}),
+  };
 
   async function getAuthHeaders() {
     if (!autoRefresh) return authHeaders;

--- a/cli/src/commands/access.js
+++ b/cli/src/commands/access.js
@@ -14,6 +14,7 @@
  */
 
 import { createClient } from "../api.js";
+import { buildMcpConnection } from "../mcp-config.js";
 import { createOutput } from "../output.js";
 import { requireProject, withErrors, formatDate } from "../helpers.js";
 
@@ -837,22 +838,28 @@ export function registerAccess(program) {
 // ── Type-specific guidance ──────────────────────────────────
 
 function _showAgentGuidance(out, agent, baseUrl) {
-  const key = agent.mcp_api_key || agent.access_key;
-  if (!key) return;
-  out.info(`\n  Access Key: ${key}\n`);
+  const connection = buildMcpConnection(agent, baseUrl);
+  if (!connection) return;
+  out.info(`\n  MCP API Key: ${connection.apiKey}`);
+  out.info("  (save this key — it won't be shown again)\n");
   out.info("  Chat:");
   out.info(`    puppyone chat ${agent.id}\n`);
-  out.info("  Connect from Claude / Cursor:");
-  out.info(`    npx -y mcp-remote ${baseUrl}/mcp?api_key=${key}`);
+  _showMcpClientConfig(out, connection);
 }
 
 function _showMcpGuidance(out, endpoint, baseUrl) {
-  const key = endpoint.api_key || endpoint.access_key;
-  if (!key) return;
-  out.info(`\n  API Key: ${key}`);
-  out.info("  (save this key \u2014 it won't be shown again)\n");
-  out.info("  Connect from Claude Desktop / Cursor:");
-  out.info(`    npx -y mcp-remote ${baseUrl}/mcp?api_key=${key}`);
+  const connection = buildMcpConnection(endpoint, baseUrl);
+  if (!connection) return;
+  out.info(`\n  API Key: ${connection.apiKey}`);
+  out.info("  (save this key — it won't be shown again)\n");
+  _showMcpClientConfig(out, connection);
+}
+
+function _showMcpClientConfig(out, connection) {
+  out.info(`  Server URL: ${connection.serverUrl}`);
+  out.info(`  Header: Authorization: ${connection.authorization}\n`);
+  out.info("  Claude Desktop / Cursor HTTP MCP config:");
+  out.info(JSON.stringify(connection.clientConfig, null, 2));
 }
 
 function _showSandboxGuidance(out, endpoint) {
@@ -892,13 +899,12 @@ function _showFsGuidance(out, connection, baseUrl, profileFallback = "file-acces
 
 function _showProviderGuidance(out, connection, baseUrl) {
   const { provider, access_key: key, id } = connection;
-  if (provider === "agent" && key) {
+  if (provider === "agent") {
     out.info("  \u2500 How to use this agent:");
-    out.info(`    Chat:         puppyone chat ${id}`);
-    out.info(`    MCP connect:  npx -y mcp-remote ${baseUrl}/mcp?api_key=${key}\n`);
-  } else if (provider === "mcp" && key) {
+    _showAgentGuidance(out, connection, baseUrl);
+  } else if (provider === "mcp") {
     out.info("  \u2500 How to connect:");
-    out.info(`    npx -y mcp-remote ${baseUrl}/mcp?api_key=${key}\n`);
+    _showMcpGuidance(out, connection, baseUrl);
   } else if (provider === "sandbox") {
     out.info("  \u2500 Execute via Agent or API.\n");
   } else if (provider === "direct" && key) {

--- a/cli/src/mcp-config.js
+++ b/cli/src/mcp-config.js
@@ -1,0 +1,32 @@
+function trimTrailingSlashes(value) {
+  return String(value || "").replace(/\/+$/, "");
+}
+
+export function buildMcpConnection(connection, apiBase) {
+  const apiKey = connection?.mcp_api_key || connection?.api_key || connection?.access_key;
+  if (!apiKey) return null;
+
+  const serverUrl = connection?.mcp_server_url
+    || `${trimTrailingSlashes(apiBase)}/api/v1/mcp/proxy`;
+  const name = String(connection?.name || connection?.id || "puppyone-mcp")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "puppyone-mcp";
+
+  return {
+    apiKey,
+    serverUrl,
+    authorization: `Bearer ${apiKey}`,
+    clientConfig: {
+      mcpServers: {
+        [name]: {
+          type: "http",
+          url: serverUrl,
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+      },
+    },
+  };
+}

--- a/cli/src/repository-contract.js
+++ b/cli/src/repository-contract.js
@@ -1,0 +1,7 @@
+export const REPOSITORY_CONTRACT_VERSION = "2";
+
+export function repositoryContractHeaders() {
+  return {
+    "X-PuppyOne-Repository-Contract": REPOSITORY_CONTRACT_VERSION,
+  };
+}

--- a/cli/tests/mcp_config.test.mjs
+++ b/cli/tests/mcp_config.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+
+import { buildMcpConnection } from "../src/mcp-config.js";
+import { repositoryContractHeaders } from "../src/repository-contract.js";
+
+
+const secret = "mcp_one_time_secret";
+const connection = buildMcpConnection(
+  {
+    id: "endpoint-1",
+    name: "Docs MCP",
+    mcp_api_key: secret,
+    mcp_server_url: "https://api.example.test/api/v1/mcp/proxy",
+  },
+  "https://ignored.example.test",
+);
+
+assert.ok(connection);
+assert.equal(connection.serverUrl, "https://api.example.test/api/v1/mcp/proxy");
+assert.equal(connection.authorization, `Bearer ${secret}`);
+assert.equal(
+  connection.clientConfig.mcpServers["docs-mcp"].headers.Authorization,
+  `Bearer ${secret}`,
+);
+assert.equal(connection.serverUrl.includes(secret), false);
+assert.equal(JSON.stringify(connection.clientConfig).includes("api_key="), false);
+assert.equal(buildMcpConnection({ id: "endpoint-1" }, "https://api.example.test"), null);
+assert.deepEqual(repositoryContractHeaders(), {
+  "X-PuppyOne-Repository-Contract": "2",
+});
+
+console.log("mcp config contract: ok");

--- a/docs/architecture/16-project-publish-control-plane.md
+++ b/docs/architecture/16-project-publish-control-plane.md
@@ -137,7 +137,6 @@ closure contains:
 
 ```text
 version/{project_id}/
-mut/{project_id}/
 projects/{project_id}/
 shadow-snapshots/{project_id}/
 users/{principal}/etl_artifacts/{project_id}/

--- a/docs/ops/issue-032-railway-database-deploy-gate.md
+++ b/docs/ops/issue-032-railway-database-deploy-gate.md
@@ -1,0 +1,91 @@
+# Qubits Railway database deployment gate
+
+This runbook configures and proves the external half of the database release
+contract. Repository CI cannot read Railway's **Wait for CI** switch, so a
+release is not accepted until an operator records exact-SHA Railway evidence.
+
+The canonical logical inventory is
+`backend/deploy/railway-qubits-services.json`. It contains five services:
+`api`, `file_worker`, `import_worker`, `sync_worker`, and `mcp_server`. Record
+the actual Railway service name and ID for each role in the release receipt;
+do not assume the display name equals `SERVICE_ROLE`.
+
+## One-time configuration
+
+For every service in the Qubits Railway environment:
+
+1. Open **Service → Settings → Source**.
+2. Confirm the connected repository is `puppyone-ai/puppyone`.
+3. Confirm the source branch is `qubits`.
+4. Set **Root Directory** to `backend` (Railway may display `/backend`).
+5. Enable **Wait for CI** under GitHub Autodeploys.
+6. Open **Variables** and record the service's `SERVICE_ROLE`. The API may omit
+   it because `api` is the default; every worker must set its explicit role.
+7. Confirm build, pre-deploy, and start settings do not run `supabase db push`.
+   Database mutation belongs only to `Deploy Database to Qubits`.
+8. Save a receipt row containing environment, Railway service name/ID,
+   `SERVICE_ROLE`, repository, branch, root directory, Wait for CI state, UTC
+   timestamp, and operator. Do not put credentials in the receipt.
+
+Run the repository-side check before and after dashboard configuration:
+
+```bash
+python backend/scripts/check_railway_release_gate.py
+```
+
+The check proves inventory and repository configuration. It deliberately does
+not claim that the external Railway switch is enabled.
+
+## Failure-blocking rehearsal
+
+Use a harmless test commit whose database workflow is intentionally cancelled
+or fails before mutation. Do not introduce invalid schema into a shared
+database.
+
+1. Record the full 40-character commit SHA.
+2. Open the GitHub Actions run named `Deploy Database to Qubits` and verify its
+   `head_sha` equals the recorded SHA and its conclusion is not `success`.
+3. For each of the five Railway services, locate the candidate deployment for
+   that exact SHA. It must be `SKIPPED` or `BLOCKED`; it must never become the
+   active deployment.
+4. Record the currently active deployment ID before and after the rehearsal.
+   The IDs must match.
+5. If any service rolls out, disable Qubits autodeploy for that service,
+   restore the previous deployment if needed, correct Wait for CI, and repeat
+   the entire rehearsal. One passing service does not cover the others.
+
+## Success-ordering rehearsal
+
+1. Push a reviewed Qubits test commit and record its full SHA.
+2. Watch `Deploy Database to Qubits`. Preserve its run URL and completion time.
+3. Confirm the workflow completed schema deployment, data lane as applicable,
+   schema smoke, drift detection, and attestation for that SHA.
+4. For every Railway service, verify its deployment references the same SHA
+   and started rollout only after the GitHub workflow succeeded.
+5. Verify API `/live` and `/ready`; verify worker process logs show the expected
+   `SERVICE_ROLE`; verify the MCP service is healthy through the API readiness
+   report. Do not expose internal secrets in captured logs.
+6. Search each deployment's build/pre-deploy/start log for `supabase db push`.
+   Any occurrence outside the GitHub database workflow fails the rehearsal.
+
+## Retry, recovery, rollback, and emergency boundary
+
+- Retry a failed database workflow for the same SHA only after diagnosing the
+  failure. A retry must not be represented as a different commit's evidence.
+- If schema deployment succeeded but a later smoke/drift step failed, keep
+  application deployment blocked and use an additive forward-fix migration.
+  Never edit or delete an applied migration.
+- Application rollback may restore the last compatible deployment. Database
+  rollback requires the migration-specific reviewed recovery plan; do not run
+  ad-hoc reverse SQL from Railway.
+- A manual Railway deploy is emergency-only. Record incident ID, approver,
+  exact SHA, database attestation, affected services, start/end time, and the
+  reason Wait for CI could not be used. Manual deploy never waives schema
+  compatibility or post-deploy health checks.
+
+## Minimal release receipt
+
+The receipt must link one GitHub run and all five Railway deployments to one
+full SHA. Include the failure rehearsal, success rehearsal, active-deployment
+continuity, health results, and reviewer sign-off. Redact tokens, database
+URLs, internal domains when required, and all request authorization headers.

--- a/supabase/data_migrations/20260712_repo_user_permissions_to_project_members/contract.pending.sql
+++ b/supabase/data_migrations/20260712_repo_user_permissions_to_project_members/contract.pending.sql
@@ -6,7 +6,7 @@
 -- silently widening or narrowing access is not an acceptable migration.
 --
 -- requires-data-migration: 20260712_repo_user_permissions_to_project_members
--- data-migration-checksum: 038bc26c63e5f192072ec74a3ab30ecbe051a8c421f6492039fe9c011bf38cdc
+-- data-migration-checksum: 649b84361ea1c8b72dfcef8f6c9e5beeafa520a1322b4d9f1ecbb79202fd6bce
 --
 -- This reviewed contract is intentionally outside supabase/migrations. Promote
 -- it by copying it to a new timestamped schema migration only after Qubits and
@@ -38,7 +38,7 @@ BEGIN
         WHERE name = '20260712_repo_user_permissions_to_project_members'
           AND COALESCE((summary->>'verified')::boolean, false)
           AND summary->>'artifact_checksum' =
-              '038bc26c63e5f192072ec74a3ab30ecbe051a8c421f6492039fe9c011bf38cdc'
+              '649b84361ea1c8b72dfcef8f6c9e5beeafa520a1322b4d9f1ecbb79202fd6bce'
     ) THEN
         RAISE EXCEPTION
           'DATA_MIGRATION_REQUIRED:20260712_repo_user_permissions_to_project_members';

--- a/supabase/data_migrations/20260712_repo_user_permissions_to_project_members/contract.pending.sql
+++ b/supabase/data_migrations/20260712_repo_user_permissions_to_project_members/contract.pending.sql
@@ -6,7 +6,7 @@
 -- silently widening or narrowing access is not an acceptable migration.
 --
 -- requires-data-migration: 20260712_repo_user_permissions_to_project_members
--- data-migration-checksum: 649b84361ea1c8b72dfcef8f6c9e5beeafa520a1322b4d9f1ecbb79202fd6bce
+-- data-migration-checksum: 038bc26c63e5f192072ec74a3ab30ecbe051a8c421f6492039fe9c011bf38cdc
 --
 -- This reviewed contract is intentionally outside supabase/migrations. Promote
 -- it by copying it to a new timestamped schema migration only after Qubits and
@@ -38,7 +38,7 @@ BEGIN
         WHERE name = '20260712_repo_user_permissions_to_project_members'
           AND COALESCE((summary->>'verified')::boolean, false)
           AND summary->>'artifact_checksum' =
-              '649b84361ea1c8b72dfcef8f6c9e5beeafa520a1322b4d9f1ecbb79202fd6bce'
+              '038bc26c63e5f192072ec74a3ab30ecbe051a8c421f6492039fe9c011bf38cdc'
     ) THEN
         RAISE EXCEPTION
           'DATA_MIGRATION_REQUIRED:20260712_repo_user_permissions_to_project_members';


### PR DESCRIPTION
Closes code-side gaps tracked by ISSUE-028, ISSUE-032, and ISSUE-043.

- pins Landing contract v1 and returns one-time MCP credentials
- emits Bearer-only CLI configuration and repository contract headers
- enforces Desktop S256 PKCE and adds local-session logout/revoke
- adds Railway role validation and exact-SHA rollout runbook
- refreshes the authorization data-migration checksum contract

Validation: 199 security/architecture tests, 27 auth tests, 154 GC/storage/billing/entitlement tests, CLI unit tests, Ruff, workflow YAML and Railway validator pass. Real Railway/Hosted MCP/Polar canary evidence remains external and is not claimed here.