### PR TITLE
Fix database drift ownership boundary

### DIFF
--- a/.github/workflows/_schema-deploy.yml
+++ b/.github/workflows/_schema-deploy.yml
@@ -128,7 +128,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if ! diff_output=$(supabase db diff --linked 2>&1); then
+          # PuppyOne owns public. A protected database may also host schemas
+          # owned by another service (for example PuppyPay's `puppypay`), which
+          # must not be adopted into or deleted by PuppyOne migrations.
+          if ! diff_output=$(supabase db diff --linked --schema public 2>&1); then
             echo "::error::Could not evaluate post-deploy schema drift."
             echo "$diff_output"
             exit 1

--- a/backend/tests/infra/data_migrations/test_workflows.py
+++ b/backend/tests/infra/data_migrations/test_workflows.py
@@ -256,6 +256,14 @@ def test_schema_runner_only_pauses_for_an_explicit_data_migration_guard() -> Non
     assert "if: steps.push.outputs.schema_state == 'deployed'" in schema
 
 
+def test_schema_drift_is_scoped_to_puppyone_owned_public_schema() -> None:
+    schema = (WORKFLOWS / "_schema-deploy.yml").read_text()
+
+    assert "supabase db diff --linked --schema public" in schema
+    assert "supabase db diff --linked 2>&1" not in schema
+    assert "PuppyPay's `puppypay`" in schema
+
+
 def test_only_historical_upgrade_harness_can_insert_missing_older_migrations() -> None:
     schema = (WORKFLOWS / "_schema-deploy.yml").read_text()
     upgrade_harness = (REPOSITORY / "scripts" / "test-repository-target-migration.sh").read_text()

--- a/docs/architecture/13-database-release-governance.md
+++ b/docs/architecture/13-database-release-governance.md
@@ -128,6 +128,12 @@ Supabase completion SQL and performs the same final schema check. The standalone
 idempotent recovery of CI-mode artifacts; `plan` and `verify` are read-only,
 while `run` mutates database data and writes a receipt after verification.
 
+The final drift check is explicitly scoped to PuppyOne's `public` schema.
+Protected databases may colocate schemas owned by another service, such as
+PuppyPay's `puppypay` schema; those schemas are neither PuppyOne migration input
+nor drift. Cross-schema platform invariants that PuppyOne depends on, including
+its trigger on `auth.users`, remain covered by the preceding smoke contracts.
+
 For the project-storage inventory, run the explicit operation from `backend/`
 against the intended environment only after a dry run:
 


### PR DESCRIPTION
## What changed

- scope the post-deploy Supabase drift check to PuppyOne's owned `public` schema
- keep cross-schema dependencies covered by the existing database smoke contracts
- add a regression test that prevents the workflow from returning to an unscoped whole-database diff
- document the ownership boundary for colocated service schemas

## Root cause

The Qubits Supabase database also hosts PuppyPay's independently owned `puppypay` schema. The release workflow ran `supabase db diff --linked` without a schema filter, so it treated that legitimate colocated schema as PuppyOne drift and failed with:

```sql
create schema if not exists "puppypay";
```

PuppyOne must neither adopt nor delete PuppyPay's schema.

## Impact

Staging and production release checks continue to fail on drift in PuppyOne's `public` schema while ignoring schemas owned by other colocated services. The preceding smoke contract still verifies PuppyOne's required trigger on `auth.users`.

## Validation

- `DEBUG=false uv run pytest tests/infra/data_migrations/test_workflows.py tests/security/test_credential_backfill_ci_contract.py -q` — 28 passed
- verified `supabase@2.107.0 db diff --help` supports `--schema`
- `git diff --check`
